### PR TITLE
Minor doc improvement

### DIFF
--- a/Documentation/deployment.md
+++ b/Documentation/deployment.md
@@ -187,7 +187,7 @@ bootcfg
 If you enabled the gRPC API,
 
 ```sh
-$ openssl s_client -connect bootcfg.example.com:8081 -CAfile /etc/bootcfg/ca.crt -cert examples/etc/bootcfg/client.crt -key examples/etc/bootcfg/client.key
+$ echo | openssl s_client -connect bootcfg.example.com:8081 -CAfile /etc/bootcfg/ca.crt -cert examples/etc/bootcfg/client.crt -key examples/etc/bootcfg/client.key
 CONNECTED(00000003)
 depth=1 CN = fake-ca
 verify return:1


### PR DESCRIPTION
Exit `openssl s_client` with the help of echo. Without the stdin from the echo command the openssl command hangs and needs to be quit manually.