### PR TITLE
ipxe: use `mac` instead of `net0/mac`

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -11,7 +11,7 @@ Serves a static iPXE boot script which gathers client machine attributes and cha
 **Response**
 
     #!ipxe
-    chain ipxe?uuid=${uuid}&mac=${net0/mac:hexhyp}&domain=${domain}&hostname=${hostname}&serial=${serial}
+    chain ipxe?uuid=${uuid}&mac=${mac:hexhyp}&domain=${domain}&hostname=${hostname}&serial=${serial}
 
 Client's booted with the `/ipxe.boot` endpoint will introspect and make a request to `/ipxe` with the `uuid`, `mac`, `hostname`, and `serial` value as query arguments.
 
@@ -32,7 +32,7 @@ Finds the profile for the machine and renders the network boot config (kernel, o
 **Response**
 
     #!ipxe
-    kernel /assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp} coreos.first_boot=1 coreos.autologin
+    kernel /assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp} coreos.first_boot=1 coreos.autologin
     initrd  /assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz
     boot
 

--- a/Documentation/matchbox.md
+++ b/Documentation/matchbox.md
@@ -65,7 +65,7 @@ Profiles reference an Ignition config, Cloud-Config, and/or generic config by na
         "kernel": "/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
         "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
         "args": [
-          "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
+          "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
           "coreos.first_boot=yes",
           "coreos.autologin"
         ]

--- a/examples/profiles/bootkube-controller.json
+++ b/examples/profiles/bootkube-controller.json
@@ -6,7 +6,7 @@
     "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "root=/dev/sda1",
-      "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
+      "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",
       "console=tty0",
       "console=ttyS0",

--- a/examples/profiles/bootkube-worker.json
+++ b/examples/profiles/bootkube-worker.json
@@ -6,7 +6,7 @@
     "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "root=/dev/sda1",
-      "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
+      "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",
       "console=tty0",
       "console=ttyS0",

--- a/examples/profiles/etcd-proxy.json
+++ b/examples/profiles/etcd-proxy.json
@@ -5,7 +5,7 @@
     "kernel": "/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
     "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
-      "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
+      "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",
       "console=tty0",
       "console=ttyS0",

--- a/examples/profiles/etcd.json
+++ b/examples/profiles/etcd.json
@@ -5,7 +5,7 @@
     "kernel": "/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
     "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
-      "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
+      "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",
       "console=tty0",
       "console=ttyS0",

--- a/examples/profiles/etcd3-proxy.json
+++ b/examples/profiles/etcd3-proxy.json
@@ -5,7 +5,7 @@
     "kernel": "/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
     "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
-      "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
+      "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",
       "console=tty0",
       "console=ttyS0",

--- a/examples/profiles/etcd3.json
+++ b/examples/profiles/etcd3.json
@@ -5,7 +5,7 @@
     "kernel": "/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
     "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
-      "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
+      "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",
       "console=tty0",
       "console=ttyS0",

--- a/examples/profiles/install-reboot.json
+++ b/examples/profiles/install-reboot.json
@@ -5,7 +5,7 @@
     "kernel": "/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
     "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
-      "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
+      "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",
       "console=tty0",
       "console=ttyS0",

--- a/examples/profiles/install-shutdown.json
+++ b/examples/profiles/install-shutdown.json
@@ -5,7 +5,7 @@
     "kernel": "/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
     "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
-      "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
+      "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",
       "console=tty0",
       "console=ttyS0",

--- a/examples/profiles/k8s-controller.json
+++ b/examples/profiles/k8s-controller.json
@@ -6,7 +6,7 @@
     "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "root=/dev/sda1",
-      "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
+      "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",
       "console=tty0",
       "console=ttyS0",

--- a/examples/profiles/k8s-worker.json
+++ b/examples/profiles/k8s-worker.json
@@ -6,7 +6,7 @@
     "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "root=/dev/sda1",
-      "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
+      "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",
       "console=tty0",
       "console=ttyS0",

--- a/examples/profiles/simple-install.json
+++ b/examples/profiles/simple-install.json
@@ -5,7 +5,7 @@
     "kernel": "/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
     "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
-      "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
+      "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",
       "console=tty0",
       "console=ttyS0",

--- a/examples/profiles/simple.json
+++ b/examples/profiles/simple.json
@@ -5,7 +5,7 @@
 		"kernel": "/assets/coreos/1185.3.0/coreos_production_pxe.vmlinuz",
 		"initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
 		"args": [
-			"coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
+			"coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
 			"coreos.first_boot=yes",
 			"console=tty0",
 			"console=ttyS0",

--- a/examples/profiles/torus.json
+++ b/examples/profiles/torus.json
@@ -6,7 +6,7 @@
     "initrd": ["/assets/coreos/1185.3.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "root=/dev/sda1",
-      "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${net0/mac:hexhyp}",
+      "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",
       "console=tty0",
       "console=ttyS0",

--- a/matchbox/http/ipxe.go
+++ b/matchbox/http/ipxe.go
@@ -11,7 +11,7 @@ import (
 )
 
 const ipxeBootstrap = `#!ipxe
-chain ipxe?uuid=${uuid}&mac=${net0/mac:hexhyp}&domain=${domain}&hostname=${hostname}&serial=${serial}
+chain ipxe?uuid=${uuid}&mac=${mac:hexhyp}&domain=${domain}&hostname=${hostname}&serial=${serial}
 `
 
 var ipxeTemplate = template.Must(template.New("iPXE config").Parse(`#!ipxe


### PR DESCRIPTION
All the ipxe, scripts and examples are using `net0/mac` as mac selector variable, when you have several interfaces and net0 is not the interface being use, the mac sent as selector, could be useless/unknown as selector.

Using just `mac` variable, the mac of the interface being use is returned, solving the issue.