### PR TITLE
scripts/devnet: Improve devnet script usability

### DIFF
--- a/scripts/devnet
+++ b/scripts/devnet
@@ -24,6 +24,7 @@ function main {
   fi
   case "$1" in
     "create") create;;
+    "status") status;;
     "destroy") destroy;;
     *)
       usage
@@ -36,6 +37,7 @@ function usage {
   echo "USAGE: ${0##*/} <command>"
   echo "Commands:"
   echo -e "\tcreate\tcreate matchbox and PXE services on the bridge"
+  echo -e "\tstatus\tshow the systemctl status of matchbox and dnsmasq"
   echo -e "\tdestroy\tdestroy the services on the bridge"
 }
 
@@ -48,6 +50,25 @@ function check {
 
   if [ ! -d $DIR/../examples/assets/coreos/$COREOS_VERSION ]; then
     echo "Most examples use CoreOS $COREOS_CHANNEL $COREOS_VERSION. You may wish to download it with './scripts/get-coreos $COREOS_CHANNEL $COREOS_VERSION'."
+  fi
+
+  if ! ip link show metal0 > /dev/null; then
+    echo "Creating the metal0 virtual bridge"
+    mkdir -p /etc/rkt/net.d
+    cat > /etc/rkt/net.d/20-metal.conf << EOF
+{
+  "name": "metal0",
+  "type": "bridge",
+  "bridge": "metal0",
+  "isGateway": true,
+  "ipMasq": true,
+  "ipam": {
+    "type": "host-local",
+    "subnet": "172.18.0.0/24",
+    "routes" : [ { "dst" : "0.0.0.0/0" } ]
+   }
+}
+EOF
   fi
 }
 
@@ -73,9 +94,11 @@ function create {
     --volume groups,kind=host,source=$DIR/../examples/groups/$EXAMPLE"
   fi
 
+  rkt rm --uuid-file=/var/run/matchbox-pod.uuid > /dev/null 2>&1
   systemd-run --unit=dev-matchbox \
     rkt run \
-    --uuid-file-save=/tmp/matchbox \
+    --uuid-file-save=/var/run/matchbox-pod.uuid \
+    --trust-keys-from-https \
     --net=metal0:IP=172.18.0.2 \
     --mount volume=config,target=/etc/matchbox \
     --volume config,kind=host,source=$PWD/examples/etc/matchbox,readOnly=true \
@@ -84,22 +107,33 @@ function create {
     quay.io/coreos/matchbox:latest -- -address=0.0.0.0:8080 -log-level=debug $MATCHBOX_ARGS
 
   echo "Starting dnsmasq to provide DHCP/TFTP/DNS services"
+  rkt rm --uuid-file=/var/run/dnsmasq-pod.uuid > /dev/null 2>&1
   systemd-run --unit=dev-dnsmasq \
     rkt run \
-    --uuid-file-save=/tmp/dnsmasq \
+    --uuid-file-save=/var/run/dnsmasq-pod.uuid \
+    --trust-keys-from-https \
     --net=metal0:IP=172.18.0.3 \
     --mount volume=config,target=/etc/dnsmasq.conf \
     --volume config,kind=host,source=$DIR/../contrib/dnsmasq/metal0.conf \
     coreos.com/dnsmasq:v0.3.0
+
+  status
+}
+
+function status {
+  echo ""
+  systemctl status dev-matchbox --lines=0 --no-pager
+  systemctl status dev-dnsmasq --lines=0 --no-pager
+  echo ""
+  echo "Use 'systemctl status dev-matchbox' or 'systemctl status dev-dnsmasq' to check individual statuses."
+  echo "Use 'journalctl -f -u dev-matchbox', etc. to tail the logs."
 }
 
 function destroy {
-  rkt stop --uuid-file=/tmp/matchbox --force
-  rkt rm --uuid-file=/tmp/matchbox
-  rkt stop --uuid-file=/tmp/dnsmasq --force
-  rkt rm --uuid-file=/tmp/dnsmasq
-  systemctl reset-failed dev-matchbox
-  systemctl reset-failed dev-dnsmasq
+  rkt stop --uuid-file=/var/run/matchbox-pod.uuid
+  rkt stop --uuid-file=/var/run/dnsmasq-pod.uuid
+  systemctl reset-failed dev-matchbox > /dev/null 2>&1
+  systemctl reset-failed dev-dnsmasq > /dev/null 2>&1
 }
 
 main $@


### PR DESCRIPTION
* Separate the stop and rm steps. Previously, users sometimes had to run devnet destroy a few times.
* Add devnet script to getting-started-rkt