### PR TITLE
internal: Add smoke testing scripts

### DIFF
--- a/internal/smoke/etcd
+++ b/internal/smoke/etcd
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -e
+
+main() {
+  cleanup
+  ./scripts/devnet create etcd3
+  ./scripts/libvirt create
+
+  until etcd "172.18.0.21" && etcd "172.18.0.22" && etcd "172.18.0.23"
+  do
+    sleep 3
+    echo "Waiting for etcd cluster..."
+  done
+
+  echo "etcd cluster came up!"
+  echo
+
+  cleanup
+}
+
+etcd() {
+  curl --silent --fail -m 1 http://$1:2379/health > /dev/null
+}
+
+cleanup() {
+  ./scripts/libvirt destroy || true
+  ./scripts/devnet destroy || true
+  rkt gc --grace-period=0
+}
+
+main $@

--- a/internal/smoke/k8s
+++ b/internal/smoke/k8s
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -e
+
+ASSETS_DIR="${ASSETS_DIR:-$PWD/examples/assets}"
+
+main() {
+  cleanup
+  ./scripts/get-kubectl
+  ./scripts/tls/k8s-certgen -d $ASSETS_DIR/tls
+  ./scripts/devnet create k8s
+  ./scripts/libvirt create
+
+  until kubelet "172.18.0.21" && kubelet "172.18.0.22" && kubelet "172.18.0.23"
+  do
+    sleep 10
+    echo "Waiting for kubelets..."
+  done
+
+  until curl --silent -k "https://172.18.0.21:443" > /dev/null
+  do
+    sleep 10
+    echo "Waiting for Kubernetes API..."
+  done
+
+  until [[ "$(readyNodes)" == "3" ]]; do
+    sleep 5
+    echo "Waiting for nodes..."
+  done
+
+  sleep 5
+
+  echo "Getting nodes..."
+  k8s get nodes
+  echo "Getting pods..."
+  k8s get pods --all-namespaces
+
+  echo "k8s cluster came up!"
+  echo
+
+  cleanup
+}
+
+k8s() {
+  ./bin/kubectl --kubeconfig=$ASSETS_DIR/tls/kubeconfig "$@"
+}
+
+kubelet() {
+  curl --silent --fail -m 1 http://$1:10255/healthz > /dev/null
+}
+
+readyNodes() {
+  k8s get nodes -o template --template='{{range .items}}{{range .status.conditions}}{{if eq .type "Ready"}}{{.}}{{end}}{{end}}{{end}}' | grep -o -E True | wc -l
+}
+
+cleanup() {
+  rm -rf $ASSETS_DIR/tls
+  ./scripts/libvirt destroy || true
+  ./scripts/devnet destroy || true
+  rkt gc --grace-period=0
+}
+
+main $@

--- a/scripts/devnet
+++ b/scripts/devnet
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Create a virtual bridge with PXE services and matchbox
 # USAGE: ./scripts/devnet create [example]
+# USAGE: ./scripts/devnet status
 # USAGE: ./scripts/devnet destroy
 set -u
 
@@ -11,6 +12,8 @@ BRIDGE=metal0
 COREOS_CHANNEL=stable
 COREOS_VERSION=1235.9.0
 MATCHBOX_ARGS=""
+
+ASSETS_DIR="${ASSETS_DIR:-$PWD/examples/assets}"
 
 if [ "$EUID" -ne 0 ]
   then echo "Please run as root"
@@ -48,7 +51,7 @@ function check {
     exit 1
   fi
 
-  if [ ! -d $DIR/../examples/assets/coreos/$COREOS_VERSION ]; then
+  if [ ! -d $ASSETS_DIR/coreos/$COREOS_VERSION ]; then
     echo "Most examples use CoreOS $COREOS_CHANNEL $COREOS_VERSION. You may wish to download it with './scripts/get-coreos $COREOS_CHANNEL $COREOS_VERSION'."
   fi
 }
@@ -67,12 +70,14 @@ function create {
     MATCHBOX_ARGS="-rpc-address=0.0.0.0:8081"
     DATA_MOUNT="--volume data,kind=host,source=$(mktemp -d) \
     --mount volume=assets,target=/var/lib/matchbox/assets \
-    --volume assets,kind=host,source=$PWD/examples/assets,readOnly=true"
+    --volume assets,kind=host,source=$ASSETS_DIR,readOnly=true"
   else
     # Mount the given EXAMPLE
     DATA_MOUNT="--volume data,kind=host,source=$PWD/examples \
     --mount volume=groups,target=/var/lib/matchbox/groups \
-    --volume groups,kind=host,source=$DIR/../examples/groups/$EXAMPLE"
+    --volume groups,kind=host,source=$DIR/../examples/groups/$EXAMPLE \
+    --mount volume=assets,target=/var/lib/matchbox/assets \
+    --volume assets,kind=host,source=$ASSETS_DIR,readOnly=true"
   fi
 
   rkt rm --uuid-file=/var/run/matchbox-pod.uuid > /dev/null 2>&1

--- a/scripts/get-kubectl
+++ b/scripts/get-kubectl
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# USAGE: ./get-kubectl bin/kubectl
+# Get the kubectl client
+set -eu
+
+DEST=${1:-"bin/kubectl"}
+VERSION="v1.5.2"
+
+URL="https://storage.googleapis.com/kubernetes-release/release/${VERSION}/bin/linux/amd64/kubectl"
+
+mkdir -p $(dirname $DEST)
+curl -L -o ${DEST} ${URL}
+chmod +x ${DEST}
+


### PR DESCRIPTION
This exposes some of the smoke testing bits to start doing this in the open.

* Smoke test etcd and k8s cluster bring-up
* Requires a suitable executor host (internal)
