### PR TITLE
cmd/matchbox: fix -address parsing when built with Go 1.8

### DIFF
--- a/cmd/matchbox/main.go
+++ b/cmd/matchbox/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 
 	"github.com/Sirupsen/logrus"
@@ -79,9 +78,6 @@ func main() {
 	}
 
 	// validate arguments
-	if url, err := url.Parse(flags.address); err != nil || url.String() == "" {
-		log.Fatal("A valid HTTP listen address is required")
-	}
 	if finfo, err := os.Stat(flags.dataPath); err != nil || !finfo.IsDir() {
 		log.Fatal("A valid -data-path is required")
 	}


### PR DESCRIPTION
* 1.8 changed the behavior of url.Parse so it is no longer appropriate for parsing values like 0.0.0.0:8080
* Pass the address directly to http.ListenAndServe which gives reasonable errors when bad values are used