### PR TITLE
Documentation/deployment.md: Added note for tectonic based matchbox example

### DIFF
--- a/Documentation/deployment.md
+++ b/Documentation/deployment.md
@@ -113,6 +113,8 @@ Environment="MATCHBOX_RPC_ADDRESS=0.0.0.0:8081"
 
 The Tectonic [Installer](https://tectonic.com/enterprise/docs/latest/install/bare-metal/index.html) uses this API. Tectonic users with a CoreOS provisioner can start with an example that enables it.
 
+*rkt must be installed to use this example. To install rkt please refer to the [rkt installation guide] (https://github.com/coreos/rkt/blob/v1.25.0/Documentation/distributions.md)*
+
 ```sh
 $ sudo cp contrib/systemd/matchbox-for-tectonic.service /etc/systemd/system/matchbox.service
 ```


### PR DESCRIPTION
The Tectonic matchbox service example relies on rkt being installed on the local host otherwise the matchbox service will fail. Added a note to the Tectonic matchbox service example section and provided a link to the rkt installation documentation.