### PR TITLE
tests: Improve Jenkins smoke testing reliability

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ parallel (
     node('fedora && bare-metal') {
       stage('etcd3') {
         timeout(time:3, unit:'MINUTES') {
-          git 'https://github.com/dghubble/matchbox.git'
+          checkout scm
           sh '''#!/bin/bash -e
           cat /etc/os-release
           export ASSETS_DIR=~/assets; ./tests/smoke/etcd3
@@ -23,7 +23,7 @@ parallel (
     node('fedora && bare-metal') {
       stage('k8s') {
         timeout(time:8, unit:'MINUTES') {
-          git 'https://github.com/dghubble/matchbox.git'
+          checkout scm          
           sh '''#!/bin/bash -e
           cat /etc/os-release
           export ASSETS_DIR=~/assets; ./tests/smoke/k8s
@@ -36,7 +36,7 @@ parallel (
     node('fedora && bare-metal') {
       stage('bootkube') {
         timeout(time:10, unit:'MINUTES') {
-          git 'https://github.com/dghubble/matchbox.git'
+          checkout scm          
           sh '''#!/bin/bash -e
           cat /etc/os-release
           chmod 600 ./tests/smoke/fake_rsa

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ parallel (
   etcd3: {
     node('fedora && bare-metal') {
       stage('etcd3') {
-        timeout(time:120, unit:'SECONDS') {
+        timeout(time:3, unit:'MINUTES') {
           git 'https://github.com/dghubble/matchbox.git'
           sh '''#!/bin/bash -e
           cat /etc/os-release

--- a/scripts/get-bootkube
+++ b/scripts/get-bootkube
@@ -12,5 +12,5 @@ if [[ ! -f $DEST/bootkube ]]; then
   mkdir -p $DEST
   curl -L -O ${URL}
   tar -C $DEST --strip-components=2 -xzf bootkube.tar.gz bin/linux/bootkube
-  chmod +x ${DEST}
+  chmod +x ${DEST}/bootkube
 fi

--- a/scripts/get-kubectl
+++ b/scripts/get-kubectl
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
-# USAGE: ./get-kubectl bin/kubectl
+# USAGE: ./get-kubectl bin
 # Get the kubectl client
 set -eu
 
-DEST=${1:-"bin/kubectl"}
+DEST=${1:-"bin"}
 VERSION="v1.5.2"
 
 URL="https://storage.googleapis.com/kubernetes-release/release/${VERSION}/bin/linux/amd64/kubectl"
 
-mkdir -p $(dirname $DEST)
-curl -L -o ${DEST} ${URL}
-chmod +x ${DEST}
-
+if [[ ! -f $DEST/kubectl ]]; then
+  mkdir -p ${DEST}
+  curl -L -o ${DEST}/kubectl ${URL}
+  chmod +x ${DEST}/kubectl
+fi

--- a/tests/smoke/bootkube
+++ b/tests/smoke/bootkube
@@ -7,6 +7,7 @@ source "${DIR}/common"
 main() {
   rm -rf assets
   cleanup
+  trap cleanup EXIT
 
   ./scripts/get-kubectl
   ./scripts/get-bootkube

--- a/tests/smoke/bootkube
+++ b/tests/smoke/bootkube
@@ -8,6 +8,7 @@ main() {
   rm -rf assets
   cleanup
 
+  ./scripts/get-kubectl
   ./scripts/get-bootkube
   ./scripts/devnet create bootkube
   ./scripts/libvirt create

--- a/tests/smoke/etcd3
+++ b/tests/smoke/etcd3
@@ -6,6 +6,8 @@ source "${DIR}/common"
 
 main() {
   cleanup
+  trap cleanup EXIT
+
   ./scripts/devnet create etcd3
   ./scripts/libvirt create
 

--- a/tests/smoke/k8s
+++ b/tests/smoke/k8s
@@ -8,6 +8,8 @@ source "${DIR}/common"
 main() {
   rm -rf $ASSETS_DIR/tls
   cleanup
+  trap cleanup EXIT
+
   ./scripts/get-kubectl
   ./scripts/tls/k8s-certgen -d $ASSETS_DIR/tls
   ./scripts/devnet create k8s


### PR DESCRIPTION
* Smoke test against the checkout scm. This tests cluster configuration changes proposed on origin branches. It does not yet build a new matchbox to test proposed code changes at the same time.
* Increase the etcd3 timeout and trap EXITs to cleanup
* Simplify bootkube and kubectl binary curling