### PR TITLE
scripts: Always download bootkube and kubectl

### DIFF
--- a/scripts/get-bootkube
+++ b/scripts/get-bootkube
@@ -8,9 +8,7 @@ VERSION="v0.3.11"
 
 URL="https://github.com/kubernetes-incubator/bootkube/releases/download/${VERSION}/bootkube.tar.gz"
 
-if [[ ! -f $DEST/bootkube ]]; then
-  mkdir -p $DEST
-  curl -L -O ${URL}
-  tar -C $DEST --strip-components=2 -xzf bootkube.tar.gz bin/linux/bootkube
-  chmod +x ${DEST}/bootkube
-fi
+mkdir -p $DEST
+curl -L -O ${URL}
+tar -C $DEST --strip-components=2 -xzf bootkube.tar.gz bin/linux/bootkube
+chmod +x ${DEST}/bootkube

--- a/scripts/get-kubectl
+++ b/scripts/get-kubectl
@@ -8,8 +8,6 @@ VERSION="v1.5.2"
 
 URL="https://storage.googleapis.com/kubernetes-release/release/${VERSION}/bin/linux/amd64/kubectl"
 
-if [[ ! -f $DEST/kubectl ]]; then
-  mkdir -p ${DEST}
-  curl -L -o ${DEST}/kubectl ${URL}
-  chmod +x ${DEST}/kubectl
-fi
+mkdir -p ${DEST}
+curl -L -o ${DEST}/kubectl ${URL}
+chmod +x ${DEST}/kubectl


### PR DESCRIPTION
* Cached bootkube binary causes smoke test failures when a new version is needed