### PR TITLE
ignition, support for include in fuze rederization

### DIFF
--- a/matchbox/http/ignition.go
+++ b/matchbox/http/ignition.go
@@ -2,10 +2,10 @@ package http
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"strings"
 
-	"context"
 	"github.com/Sirupsen/logrus"
 	fuze "github.com/coreos/fuze/config"
 	ignition "github.com/coreos/ignition/config"
@@ -82,7 +82,8 @@ func (s *Server) ignitionHandler(core server.Server) ContextHandler {
 
 		// render the template for an Ignition config with data
 		var buf bytes.Buffer
-		err = s.renderTemplate(&buf, data, contents)
+		funcs := s.templateFuncMap(ctx, core)
+		err = s.renderTemplateWithFuncMap(&buf, funcs, data, contents)
 		if err != nil {
 			http.NotFound(w, req)
 			return

--- a/matchbox/http/ignition.go
+++ b/matchbox/http/ignition.go
@@ -91,6 +91,7 @@ func (s *Server) ignitionHandler(core server.Server) ContextHandler {
 
 		// Parse bytes into a Fuze Config
 		config, report := fuze.Parse(buf.Bytes())
+
 		if report.IsFatal() {
 			s.logger.Errorf("error parsing Fuze config: %s", report.String())
 			http.NotFound(w, req)

--- a/matchbox/http/ignition_test.go
+++ b/matchbox/http/ignition_test.go
@@ -84,15 +84,12 @@ systemd:
       enable: true
     - name: {{.uuid}}.service
       enable: true
-
-
-{{ include "nested.partial.yaml" . }}
+{{include "nested.partial.yaml" . | indent 4 }}
 `
 
-	nestedPartial := `
-    - name: {{.request.query.foo}}.service
-      enable: true
-      contents: {{.request.raw_query}}
+	nestedPartial := `- name: {{.request.query.foo}}.service
+  enable: true
+  contents: {{.request.raw_query}}
 `
 
 	content := `

--- a/matchbox/http/ignition_test.go
+++ b/matchbox/http/ignition_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"context"
+
 	logtest "github.com/Sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 
@@ -56,6 +57,55 @@ systemd:
 	store := &fake.FixedStore{
 		Profiles:        map[string]*storagepb.Profile{fake.Group.Profile: testProfileIgnitionYAML},
 		IgnitionConfigs: map[string]string{testProfileIgnitionYAML.IgnitionId: content},
+	}
+	logger, _ := logtest.NewNullLogger()
+	srv := NewServer(&Config{Logger: logger})
+	c := server.NewServer(&server.Config{Store: store})
+	h := srv.ignitionHandler(c)
+	ctx := withGroup(context.Background(), fake.Group)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/?foo=some-param&bar=b", nil)
+	h.ServeHTTP(ctx, w, req)
+	// assert that:
+	// - Fuze template rendered with Group selectors, metadata, and query variables
+	// - Transformed to an Ignition config (JSON)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, jsonContentType, w.HeaderMap.Get(contentType))
+	assert.Equal(t, expectedIgnitionV2, w.Body.String())
+}
+
+func TestIgnitionHandler_V2YAML_Include(t *testing.T) {
+	// exercise templating features, not a realistic Fuze template
+
+	partial := `
+systemd:
+  units:
+    - name: {{.service_name}}.service
+      enable: true
+    - name: {{.uuid}}.service
+      enable: true
+
+
+{{ include "nested.partial.yaml" . }}
+`
+
+	nestedPartial := `
+    - name: {{.request.query.foo}}.service
+      enable: true
+      contents: {{.request.raw_query}}
+`
+
+	content := `
+{{ include "partial.yaml" . }}
+`
+	expectedIgnitionV2 := `{"ignition":{"version":"2.0.0","config":{}},"storage":{},"systemd":{"units":[{"name":"etcd2.service","enable":true},{"name":"a1b2c3d4.service","enable":true},{"name":"some-param.service","enable":true,"contents":"foo=some-param\u0026bar=b"}]},"networkd":{},"passwd":{}}`
+	store := &fake.FixedStore{
+		Profiles: map[string]*storagepb.Profile{fake.Group.Profile: testProfileIgnitionYAML},
+		IgnitionConfigs: map[string]string{
+			testProfileIgnitionYAML.IgnitionId: content,
+			"partial.yaml":                     partial,
+			"nested.partial.yaml":              nestedPartial,
+		},
 	}
 	logger, _ := logtest.NewNullLogger()
 	srv := NewServer(&Config{Logger: logger})

--- a/matchbox/http/render.go
+++ b/matchbox/http/render.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"text/template"
 
+	"strings"
+
 	"github.com/coreos/matchbox/matchbox/server"
 )
 
@@ -64,6 +66,16 @@ func (s *Server) renderTemplateWithFuncMap(
 
 func (s *Server) templateFuncMap(ctx context.Context, core server.Server) template.FuncMap {
 	return template.FuncMap{
+		"indent": func(spaces int, content string) string {
+			lines := strings.Split(content, "\n")
+
+			var output string
+			for _, line := range lines {
+				output += "\n" + strings.Repeat(" ", spaces) + line
+			}
+
+			return output
+		},
 		"include": func(name string, data interface{}) (string, error) {
 			contents, err := core.IgnitionGet(ctx, name)
 			if err != nil {


### PR DESCRIPTION
This PR introduce the ability to include partial include files, inside other files, allowing to remove duplicated code:

The concept is similar to the [include function in helm](https://github.com/kubernetes/helm/blob/master/docs/chart_template_guide/named_templates.md#the-include-function), as in helm, also implements an indent function to avoid the indentation problems. 

main.yaml:
```yaml
systemd:
  units:
    - name: {{.service_name}}.service
      enable: true
    - name: {{.uuid}}.service
      enable: true

{{ include "partial.yaml" . | indent 4 }}
```

partial.yaml: 
```yaml
- name: {{.request.query.foo}}.service
  enable: true
  contents: {{.request.raw_query}}
```

If this is something that could be interesting to merge I will be happy to update the documentation.

Related to: https://github.com/coreos/matchbox/issues/461

