### PR TITLE
examples: Update Kubernetes (static, self-hosted, rktnetes) to v1.5.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,8 @@ Notable changes between releases.
 
 ### Examples
 
-* Upgrade Kubernetes v1.5.4 (static) example clusters
-* Upgrade Kubernetes v1.5.4 (self-hosted) example cluster
+* Upgrade Kubernetes v1.5.5 (static) example clusters
+* Upgrade Kubernetes v1.5.5 (self-hosted) example cluster
 * Use etcd3 by default in all clusters (remove etcd2 clusters)
 
 ## v0.5.0 (2017-01-23) 

--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -1,7 +1,7 @@
 
 # Self-hosted Kubernetes
 
-The self-hosted Kubernetes example provisions a 3 node "self-hosted" Kubernetes v1.5.4 cluster. On-host kubelets wait for an apiserver to become reachable, then yield to kubelet pods scheduled via daemonset. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run on any controller to bootstrap a temporary apiserver which schedules control plane components as pods before exiting. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
+The self-hosted Kubernetes example provisions a 3 node "self-hosted" Kubernetes v1.5.5 cluster. On-host kubelets wait for an apiserver to become reachable, then yield to kubelet pods scheduled via daemonset. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run on any controller to bootstrap a temporary apiserver which schedules control plane components as pods before exiting. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
 
 ## Requirements
 
@@ -12,13 +12,13 @@ Ensure that you've gone through the [matchbox with rkt](getting-started-rkt.md) 
 * Create the example libvirt client VMs
 * `/etc/hosts` entries for `node[1-3].example.com` (or pass custom names to `k8s-certgen`)
 
-Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.3.11 and add it somewhere on your PATH.
+Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.3.12 and add it somewhere on your PATH.
 
 ```sh
-$ wget https://github.com/kubernetes-incubator/bootkube/releases/download/v0.3.11/bootkube.tar.gz
+$ wget https://github.com/kubernetes-incubator/bootkube/releases/download/v0.3.12/bootkube.tar.gz
 $ tar xzf bootkube.tar.gz
 $ ./bin/linux/bootkube version
-Version: v0.3.11
+Version: v0.3.12
 ```
 
 ## Examples

--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -1,6 +1,6 @@
 # Kubernetes
 
-The Kubernetes example provisions a 3 node Kubernetes v1.5.4 cluster with one controller, two workers, and TLS authentication. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
+The Kubernetes example provisions a 3 node Kubernetes v1.5.5 cluster with one controller, two workers, and TLS authentication. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
 
 ## Requirements
 

--- a/Documentation/rktnetes.md
+++ b/Documentation/rktnetes.md
@@ -1,6 +1,6 @@
 # Kubernetes (with rkt)
 
-The `rktnetes` example provisions a 3 node Kubernetes v1.5.4 cluster with [rkt](https://github.com/coreos/rkt) as the container runtime. The cluster has one controller, two workers, and TLS authentication. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
+The `rktnetes` example provisions a 3 node Kubernetes v1.5.5 cluster with [rkt](https://github.com/coreos/rkt) as the container runtime. The cluster has one controller, two workers, and TLS authentication. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
 
 ## Requirements
 

--- a/examples/ignition/bootkube-controller.yaml
+++ b/examples/ignition/bootkube-controller.yaml
@@ -117,7 +117,7 @@ storage:
       contents:
         inline: |
           KUBELET_ACI=quay.io/coreos/hyperkube
-          KUBELET_VERSION=v1.5.4_coreos.0
+          KUBELET_VERSION=v1.5.5_coreos.0
     - path: /etc/hostname
       filesystem: root
       mode: 0644
@@ -142,7 +142,7 @@ storage:
           # Wrapper for bootkube start
           set -e
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.3.11}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.3.12}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/opt/bootkube/assets}"
           exec /usr/bin/rkt run \
             --trust-keys-from-https \

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -106,7 +106,7 @@ storage:
       contents:
         inline: |
           KUBELET_ACI=quay.io/coreos/hyperkube
-          KUBELET_VERSION=v1.5.4_coreos.0
+          KUBELET_VERSION=v1.5.5_coreos.0
     - path: /etc/hostname
       filesystem: root
       mode: 0644

--- a/examples/ignition/k8s-controller.yaml
+++ b/examples/ignition/k8s-controller.yaml
@@ -64,7 +64,7 @@ systemd:
         Requires=k8s-assets.target
         After=k8s-assets.target
         [Service]
-        Environment=KUBELET_VERSION=v1.5.4_coreos.0
+        Environment=KUBELET_VERSION=v1.5.5_coreos.0
         Environment="RKT_OPTS=--uuid-file-save=/var/run/kubelet-pod.uuid \
           --volume dns,kind=host,source=/etc/resolv.conf \
           --mount volume=dns,target=/etc/resolv.conf \
@@ -194,7 +194,7 @@ storage:
             hostNetwork: true
             containers:
             - name: kube-proxy
-              image: quay.io/coreos/hyperkube:v1.5.4_coreos.0
+              image: quay.io/coreos/hyperkube:v1.5.5_coreos.0
               command:
               - /hyperkube
               - proxy
@@ -228,7 +228,7 @@ storage:
             hostNetwork: true
             containers:
             - name: kube-apiserver
-              image: quay.io/coreos/hyperkube:v1.5.4_coreos.0
+              image: quay.io/coreos/hyperkube:v1.5.5_coreos.0
               command:
               - /hyperkube
               - apiserver
@@ -289,7 +289,7 @@ storage:
           spec:
             containers:
             - name: kube-controller-manager
-              image: quay.io/coreos/hyperkube:v1.5.4_coreos.0
+              image: quay.io/coreos/hyperkube:v1.5.5_coreos.0
               command:
               - /hyperkube
               - controller-manager
@@ -335,7 +335,7 @@ storage:
             hostNetwork: true
             containers:
             - name: kube-scheduler
-              image: quay.io/coreos/hyperkube:v1.5.4_coreos.0
+              image: quay.io/coreos/hyperkube:v1.5.5_coreos.0
               command:
               - /hyperkube
               - scheduler

--- a/examples/ignition/k8s-worker.yaml
+++ b/examples/ignition/k8s-worker.yaml
@@ -58,7 +58,7 @@ systemd:
         Requires=k8s-assets.target
         After=k8s-assets.target
         [Service]
-        Environment=KUBELET_VERSION=v1.5.4_coreos.0
+        Environment=KUBELET_VERSION=v1.5.5_coreos.0
         Environment="RKT_OPTS=--uuid-file-save=/var/run/kubelet-pod.uuid \
           --volume dns,kind=host,source=/etc/resolv.conf \
           --mount volume=dns,target=/etc/resolv.conf \
@@ -201,7 +201,7 @@ storage:
             hostNetwork: true
             containers:
             - name: kube-proxy
-              image: quay.io/coreos/hyperkube:v1.5.4_coreos.0
+              image: quay.io/coreos/hyperkube:v1.5.5_coreos.0
               command:
               - /hyperkube
               - proxy

--- a/scripts/get-bootkube
+++ b/scripts/get-bootkube
@@ -4,7 +4,7 @@
 set -eu
 
 DEST=${1:-"bin"}
-VERSION="v0.3.11"
+VERSION="v0.3.12"
 
 URL="https://github.com/kubernetes-incubator/bootkube/releases/download/${VERSION}/bootkube.tar.gz"
 

--- a/scripts/get-kubectl
+++ b/scripts/get-kubectl
@@ -4,7 +4,7 @@
 set -eu
 
 DEST=${1:-"bin"}
-VERSION="v1.5.4"
+VERSION="v1.5.5"
 
 URL="https://storage.googleapis.com/kubernetes-release/release/${VERSION}/bin/linux/amd64/kubectl"
 


### PR DESCRIPTION
* Bump kubectl version to v1.5.5
* Bump bootkube to v0.3.12

Smoke tests: https://jenkins-tectonic.prod.coreos.systems/job/matchbox/job/update-kubernetes/

cc @aaronlevy @ericchiang 