### PR TITLE
examples: Update self-hosted Kubernetes to v1.5.6

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ Notable changes between releases.
 ### Examples
 
 * Upgrade Kubernetes v1.5.5 (static) example clusters
-* Upgrade Kubernetes v1.5.5 (self-hosted) example cluster
+* Upgrade Kubernetes v1.5.6 (self-hosted) example cluster
 * Use etcd3 by default in all clusters (remove etcd2 clusters)
 
 ## v0.5.0 (2017-01-23) 

--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -1,7 +1,7 @@
 
 # Self-hosted Kubernetes
 
-The self-hosted Kubernetes example provisions a 3 node "self-hosted" Kubernetes v1.5.5 cluster. On-host kubelets wait for an apiserver to become reachable, then yield to kubelet pods scheduled via daemonset. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run on any controller to bootstrap a temporary apiserver which schedules control plane components as pods before exiting. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
+The self-hosted Kubernetes example provisions a 3 node "self-hosted" Kubernetes v1.5.6 cluster. On-host kubelets wait for an apiserver to become reachable, then yield to kubelet pods scheduled via daemonset. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run on any controller to bootstrap a temporary apiserver which schedules control plane components as pods before exiting. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
 
 ## Requirements
 
@@ -12,13 +12,13 @@ Ensure that you've gone through the [matchbox with rkt](getting-started-rkt.md) 
 * Create the example libvirt client VMs
 * `/etc/hosts` entries for `node[1-3].example.com` (or pass custom names to `k8s-certgen`)
 
-Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.3.12 and add it somewhere on your PATH.
+Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.3.13 and add it somewhere on your PATH.
 
 ```sh
-$ wget https://github.com/kubernetes-incubator/bootkube/releases/download/v0.3.12/bootkube.tar.gz
+$ wget https://github.com/kubernetes-incubator/bootkube/releases/download/v0.3.13/bootkube.tar.gz
 $ tar xzf bootkube.tar.gz
 $ ./bin/linux/bootkube version
-Version: v0.3.12
+Version: v0.3.13
 ```
 
 ## Examples

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ parallel (
   k8s: {
     node('fedora && bare-metal') {
       stage('k8s') {
-        timeout(time:8, unit:'MINUTES') {
+        timeout(time:12, unit:'MINUTES') {
           checkout scm          
           sh '''#!/bin/bash -e
           cat /etc/os-release

--- a/examples/ignition/bootkube-controller.yaml
+++ b/examples/ignition/bootkube-controller.yaml
@@ -117,7 +117,7 @@ storage:
       contents:
         inline: |
           KUBELET_ACI=quay.io/coreos/hyperkube
-          KUBELET_VERSION=v1.5.5_coreos.0
+          KUBELET_VERSION=v1.5.6_coreos.0
     - path: /etc/hostname
       filesystem: root
       mode: 0644
@@ -142,7 +142,7 @@ storage:
           # Wrapper for bootkube start
           set -e
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.3.12}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.3.13}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/opt/bootkube/assets}"
           exec /usr/bin/rkt run \
             --trust-keys-from-https \

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -106,7 +106,7 @@ storage:
       contents:
         inline: |
           KUBELET_ACI=quay.io/coreos/hyperkube
-          KUBELET_VERSION=v1.5.5_coreos.0
+          KUBELET_VERSION=v1.5.6_coreos.0
     - path: /etc/hostname
       filesystem: root
       mode: 0644

--- a/scripts/get-bootkube
+++ b/scripts/get-bootkube
@@ -4,7 +4,7 @@
 set -eu
 
 DEST=${1:-"bin"}
-VERSION="v0.3.12"
+VERSION="v0.3.13"
 
 URL="https://github.com/kubernetes-incubator/bootkube/releases/download/${VERSION}/bootkube.tar.gz"
 


### PR DESCRIPTION
* Bump bootkube to v0.3.13
* Use hyperkube v1.5.6_coreos.0