### PR TITLE
contrib/k8s: Run matchbox on Kubernetes behind Ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Network boot and provision CoreOS clusters on virtual or physical hardware.
 * [HTTP API](Documentation/api.md)
 * [gRPC API](https://godoc.org/github.com/coreos/matchbox/matchbox/client)
 * Installation
-    * [CoreOS / Linux distros](Documentation/deployment.md)
-    * [rkt](Documentation/deployment.md#rkt) / [docker](Documentation/deployment.md#docker)
-    * [Kubernetes](Documentation/deployment.md#kubernetes)
+    * Installing on [CoreOS / Linux distros](Documentation/deployment.md)
+    * Installing on [Kubernetes](Documentation/deployment.md#kubernetes)
+    * Running with [rkt](Documentation/deployment.md#rkt) / [docker](Documentation/deployment.md#docker)
 
 ### Examples
 

--- a/contrib/k8s/matchbox-deployment.yaml
+++ b/contrib/k8s/matchbox-deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: matchbox
-  namespace: default
 spec:
   replicas: 1
   strategy:
@@ -18,41 +17,44 @@ spec:
         - name: matchbox
           image: quay.io/coreos/matchbox:v0.5.0
           env:
-            - {name: MATCHBOX_ADDRESS, value: "0.0.0.0:8080"}
-            - {name: MATCHBOX_LOG_LEVEL, value: "debug"}
+            - name: MATCHBOX_ADDRESS
+              value: "0.0.0.0:8080"
+            - name: MATCHBOX_RPC_ADDRESS
+              value: "0.0.0.0:8081"
+            - name: MATCHBOX_LOG_LEVEL
+              value: "debug"
           ports:
-            # port exposed on pod IP
-            - containerPort: 8080
+            - name: http
+              containerPort: 8080
+            - name: https
+              containerPort: 8081
           resources:
             requests:
               cpu: "50m"
               memory: "50Mi"
           volumeMounts:
+            - name: config
+              mountPath: /etc/matchbox
             - name: groups
               mountPath: /var/lib/matchbox/groups
             - name: profiles
               mountPath: /var/lib/matchbox/profiles
             - name: ignition
               mountPath: /var/lib/matchbox/ignition
-            - name: cloud
-              mountPath: /var/lib/matchbox/cloud
-            - name: generic
-              mountPath: /var/lib/matchbox/generic
             - name: assets
               mountPath: /var/lib/matchbox/assets
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
       volumes:
+        - name: config
+          secret:
+            secretName: matchbox-rpc
         - name: groups
           emptyDir: {}
         - name: profiles
           emptyDir: {}
         - name: ignition
-          emptyDir: {}
-        - name: cloud
-          emptyDir: {}
-        - name: generic
           emptyDir: {}
         - name: assets
           emptyDir: {}

--- a/contrib/k8s/matchbox-ingress.yaml
+++ b/contrib/k8s/matchbox-ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: matchbox
+  annotations:
+    ingress.kubernetes.io/ssl-passthrough: "true"
+spec:
+  tls:
+    - hosts:
+        - matchbox-rpc.example.com
+  rules:
+    - host: matchbox.example.com
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: matchbox
+              servicePort: 8080
+    - host: matchbox-rpc.example.com
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: matchbox
+              servicePort: 8081

--- a/contrib/k8s/matchbox-service.yaml
+++ b/contrib/k8s/matchbox-service.yaml
@@ -3,14 +3,16 @@ kind: Service
 metadata:
   name: matchbox
 spec:
-  type: NodePort
+  type: ClusterIP
   selector:
     name: matchbox
     phase: prod
   ports:
-    - protocol: TCP
-      port: 80
-      # port exposed on each node
-      nodePort: 31488
-      # name or port exposed on targeted pod(s)
+    - name: http
+      protocol: TCP
+      port: 8080
       targetPort: 8080
+    - name: https
+      protocol: TCP
+      port: 8081
+      targetPort: 8081


### PR DESCRIPTION
Demonstrate deploying a public matchbox behind Ingress and verify Terraform apply can update machine configs.

* Show matchbox deployment, service, and TLS secret creation
* Provide an Ingress resource for exposing HTTP and gRPC APIs
* Add note mentioning matchbox can be run publicly if best practices are followed

Note: 
* Guides for the different ways to correctly run Nginx Ingress Controllers on a bare-metal cluster is left for a future document.
* Tutorials on how to use the alpha Terraform plugin are left for a future document