### PR TITLE
examples: Upgrade self-hosted Kubernetes to v1.6.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ Notable changes between releases.
 ### Examples
 
 * Upgrade Kubernetes v1.5.5 (static) example clusters
-* Upgrade Kubernetes v1.5.6 (self-hosted) example cluster
+* Upgrade Kubernetes v1.6.1 (self-hosted) example cluster
 * Use etcd3 by default in all clusters (remove etcd2 clusters)
 
 ## v0.5.0 (2017-01-23) 

--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -1,7 +1,6 @@
-
 # Self-hosted Kubernetes
 
-The self-hosted Kubernetes example provisions a 3 node "self-hosted" Kubernetes v1.5.6 cluster. On-host kubelets wait for an apiserver to become reachable, then yield to kubelet pods scheduled via daemonset. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run on any controller to bootstrap a temporary apiserver which schedules control plane components as pods before exiting. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
+The self-hosted Kubernetes example provisions a 3 node "self-hosted" Kubernetes v1.6.1 cluster. On-host kubelets wait for an apiserver to become reachable, then yield to kubelet pods scheduled via daemonset. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run on any controller to bootstrap a temporary apiserver which schedules control plane components as pods before exiting. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
 
 ## Requirements
 
@@ -12,13 +11,11 @@ Ensure that you've gone through the [matchbox with rkt](getting-started-rkt.md) 
 * Create the example libvirt client VMs
 * `/etc/hosts` entries for `node[1-3].example.com` (or pass custom names to `k8s-certgen`)
 
-Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.3.13 and add it somewhere on your PATH.
+Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.4.0 and add it somewhere on your PATH.
 
 ```sh
-$ wget https://github.com/kubernetes-incubator/bootkube/releases/download/v0.3.13/bootkube.tar.gz
-$ tar xzf bootkube.tar.gz
-$ ./bin/linux/bootkube version
-Version: v0.3.13
+$ bootkube version
+Version: v0.4.0
 ```
 
 ## Examples

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ parallel (
   bootkube: {
     node('fedora && bare-metal') {
       stage('bootkube') {
-        timeout(time:10, unit:'MINUTES') {
+        timeout(time:12, unit:'MINUTES') {
           checkout scm          
           sh '''#!/bin/bash -e
           cat /etc/os-release

--- a/examples/ignition/bootkube-controller.yaml
+++ b/examples/ignition/bootkube-controller.yaml
@@ -59,9 +59,9 @@ systemd:
           --mount volume=var-log,target=/var/log"
         EnvironmentFile=/etc/kubernetes/kubelet.env
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
+        ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
+        ExecStartPre=/bin/mkdir -p /etc/kubernetes/inactive-manifests
         ExecStartPre=/bin/mkdir -p /var/lib/cni
         ExecStartPre=/usr/bin/bash -c "grep 'certificate-authority-data' /etc/kubernetes/kubeconfig | awk '{print $2}' | base64 -d > /etc/kubernetes/ca.crt"
         ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
@@ -117,7 +117,7 @@ storage:
       contents:
         inline: |
           KUBELET_ACI=quay.io/coreos/hyperkube
-          KUBELET_VERSION=v1.5.6_coreos.0
+          KUBELET_VERSION=v1.6.1_coreos.0
     - path: /etc/hostname
       filesystem: root
       mode: 0644
@@ -141,15 +141,20 @@ storage:
           #!/bin/bash
           # Wrapper for bootkube start
           set -e
+          mkdir -p /tmp/bootkube
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.3.13}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.4.0}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/opt/bootkube/assets}"
           exec /usr/bin/rkt run \
             --trust-keys-from-https \
             --volume assets,kind=host,source=$BOOTKUBE_ASSETS \
             --mount volume=assets,target=/assets \
+            --volume bootstrap,kind=host,source=/etc/kubernetes/manifests \
+            --mount volume=bootstrap,target=/etc/kubernetes/manifests \
+            --volume temp,kind=host,source=/tmp/bootkube \
+            --mount volume=temp,target=/tmp/bootkube \
             $RKT_OPTS \
-            ${BOOTKUBE_ACI}:${BOOTKUBE_VERSION} --net=host --exec=/bootkube -- start --asset-dir=/assets --etcd-server=http://127.0.0.1:2379 "$@"
+            ${BOOTKUBE_ACI}:${BOOTKUBE_VERSION} --net=host --exec=/bootkube -- start --asset-dir=/assets "$@"
 
 {{ if index . "ssh_authorized_keys" }}
 passwd:

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -56,9 +56,9 @@ systemd:
           --mount volume=var-log,target=/var/log"
         EnvironmentFile=/etc/kubernetes/kubelet.env
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
+        ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
+        ExecStartPre=/bin/mkdir -p /etc/kubernetes/inactive-manifests
         ExecStartPre=/bin/mkdir -p /var/lib/cni
         ExecStartPre=/usr/bin/bash -c "grep 'certificate-authority-data' /etc/kubernetes/kubeconfig | awk '{print $2}' | base64 -d > /etc/kubernetes/ca.crt"
         ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
@@ -106,7 +106,7 @@ storage:
       contents:
         inline: |
           KUBELET_ACI=quay.io/coreos/hyperkube
-          KUBELET_VERSION=v1.5.6_coreos.0
+          KUBELET_VERSION=v1.6.1_coreos.0
     - path: /etc/hostname
       filesystem: root
       mode: 0644

--- a/scripts/get-bootkube
+++ b/scripts/get-bootkube
@@ -4,7 +4,7 @@
 set -eu
 
 DEST=${1:-"bin"}
-VERSION="v0.3.13"
+VERSION="v0.4.0"
 
 URL="https://github.com/kubernetes-incubator/bootkube/releases/download/${VERSION}/bootkube.tar.gz"
 


### PR DESCRIPTION
* Render self-hosted assets with bootkube v0.4.0
* Relax bootkube smoke test Jenkins timeout