### PR TITLE
Update docs, changelog, and scripts for dnsmasq:v0.4.0

### DIFF
--- a/Documentation/grub.md
+++ b/Documentation/grub.md
@@ -1,4 +1,3 @@
-
 # GRUB2 netboot
 
 Use GRUB to network boot UEFI hardware.
@@ -23,10 +22,25 @@ On Fedora, add the `metal0` interface to the trusted zone in your firewall confi
 $ sudo firewall-cmd --add-interface=metal0 --zone=trusted
 ```
 
-Run the `coreos.com/dnsmasq` ACI with rkt.
+Run the `quay.io/coreos/dnsmasq` container image with rkt or docker.
 
 ```sh
-$ sudo rkt run coreos.com/dnsmasq:v0.3.0 --net=metal0:IP=172.18.0.3 -- -d -q --dhcp-range=172.18.0.50,172.18.0.99 --enable-tftp --tftp-root=/var/lib/tftpboot --dhcp-match=set:efi-bc,option:client-arch,7 --dhcp-boot=tag:efi-bc,grub.efi --dhcp-userclass=set:grub,GRUB2 --dhcp-boot=tag:grub,"(http;matchbox.foo:8080)/grub","172.18.0.2" --log-queries --log-dhcp --dhcp-userclass=set:ipxe,iPXE --dhcp-boot=tag:pxe,undionly.kpxe --dhcp-boot=tag:ipxe,http://matchbox.foo:8080/boot.ipxe --address=/matchbox.foo/172.18.0.2
+sudo rkt run --net=metal0:IP=172.18.0.3 quay.io/coreos/dnsmasq \
+  --caps-retain=CAP_NET_ADMIN,CAP_NET_BIND_SERVICE \
+  -- -d -q \
+  --dhcp-range=172.18.0.50,172.18.0.99 \
+  --enable-tftp \
+  --tftp-root=/var/lib/tftpboot \
+  --dhcp-match=set:efi-bc,option:client-arch,7 \
+  --dhcp-boot=tag:efi-bc,grub.efi \
+  --dhcp-userclass=set:grub,GRUB2 \
+  --dhcp-boot=tag:grub,"(http;matchbox.example.com:8080)/grub","172.18.0.2" \
+  --log-queries \
+  --log-dhcp \
+  --dhcp-userclass=set:ipxe,iPXE \
+  --dhcp-boot=tag:pxe,undionly.kpxe \
+  --dhcp-boot=tag:ipxe,http://matchbox.example.com:8080/boot.ipxe \
+  --address=/matchbox.foo/172.18.0.2
 ```
 
 ## Client VM

--- a/contrib/dnsmasq/CHANGES.md
+++ b/contrib/dnsmasq/CHANGES.md
@@ -1,0 +1,13 @@
+# dnsmasq
+
+Notable changes image releases. The dnsmasq project [upstream](http://www.thekelleys.org.uk/dnsmasq/doc.html) has its own [changelog](http://www.thekelleys.org.uk/dnsmasq/CHANGELOG).
+
+## v0.4.0
+
+* `dnsmasq` package version 2.76
+* Rebuild with alpine:3.5 base image to receive patches
+* Update CoreOS `grub.efi` to be recent (stable, 1298.7.0)
+
+## v0.3.0
+
+* `dnsmasq` package version 2.75

--- a/contrib/dnsmasq/Makefile
+++ b/contrib/dnsmasq/Makefile
@@ -12,8 +12,8 @@ undionly:
 
 .PHONY: docker-image
 docker-image: undionly
-	sudo docker build --rm=true -t $(IMAGE_REPO):$(VERSION) .
-	sudo docker tag $(IMAGE_REPO):$(VERSION) $(IMAGE_REPO):latest
+	@sudo docker build --rm=true -t $(IMAGE_REPO):$(VERSION) .
+	@sudo docker tag $(IMAGE_REPO):$(VERSION) $(IMAGE_REPO):latest
 
 .PHONY: docker-push
 docker-push:

--- a/scripts/devnet
+++ b/scripts/devnet
@@ -102,7 +102,7 @@ function create {
     --dns=host \
     --mount volume=config,target=/etc/dnsmasq.conf \
     --volume config,kind=host,source=$DIR/../contrib/dnsmasq/metal0.conf \
-    quay.io/coreos/dnsmasq:v0.3.0 \
+    quay.io/coreos/dnsmasq:v0.4.0 \
     --caps-retain="CAP_NET_ADMIN,CAP_NET_BIND_SERVICE"
 
   status


### PR DESCRIPTION
* [quay.io/coreos/dnsmasq](https://quay.io/repository/coreos/dnsmasq) v0.4.0 is available
    * dnsmasq package version 2.76
   * Rebuilds with alpine:3.5 base image to receive patches
    * Updates CoreOS `grub.efi` to be recent (stable, 1298.7.0)
* Update docs `coreos.com/dnsmasq` ACI references to `quay.io/coreos/dnsmasq`. Specify v0.4.0 when appropriate
* Update Jenkins CI to use the new dnsmasq:v0.4.0 image