### PR TITLE
examples: Sync with bootkube and etcd3

### DIFF
--- a/examples/ignition/bootkube-controller.yaml
+++ b/examples/ignition/bootkube-controller.yaml
@@ -7,7 +7,7 @@ systemd:
         - name: 40-etcd-cluster.conf
           contents: |
             [Service]
-            Environment="ETCD_IMAGE_TAG=v3.1.0"
+            Environment="ETCD_IMAGE_TAG=v3.1.6"
             Environment="ETCD_NAME={{.etcd_name}}"
             Environment="ETCD_ADVERTISE_CLIENT_URLS=http://{{.domain_name}}:2379"
             Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=http://{{.domain_name}}:2380"

--- a/examples/ignition/bootkube-controller.yaml
+++ b/examples/ignition/bootkube-controller.yaml
@@ -50,14 +50,15 @@ systemd:
         [Unit]
         Description=Kubelet via Hyperkube ACI
         [Service]
-        Environment="RKT_OPTS=--uuid-file-save=/var/run/kubelet-pod.uuid \
+        Environment=KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
+        Environment=KUBELET_IMAGE_TAG=v1.6.1_coreos.0
+        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid \
           --volume=resolv,kind=host,source=/etc/resolv.conf \
           --mount volume=resolv,target=/etc/resolv.conf \
           --volume var-lib-cni,kind=host,source=/var/lib/cni \
           --mount volume=var-lib-cni,target=/var/lib/cni \
           --volume var-log,kind=host,source=/var/log \
           --mount volume=var-log,target=/var/log"
-        EnvironmentFile=/etc/kubernetes/kubelet.env
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
@@ -78,6 +79,7 @@ systemd:
           --allow-privileged \
           --hostname-override={{.domain_name}} \
           --node-labels=master=true \
+          --node-labels=node-role.kubernetes.io/master \
           --cluster_dns={{.k8s_dns_service_ip}} \
           --cluster_domain=cluster.local
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
@@ -111,13 +113,12 @@ storage:
             - "-LROOT"
   {{end}}
   files:
-    - path: /etc/kubernetes/kubelet.env
+    - path: /etc/kubernetes/.empty
       filesystem: root
       mode: 0644
       contents:
         inline: |
-          KUBELET_ACI=quay.io/coreos/hyperkube
-          KUBELET_VERSION=v1.6.1_coreos.0
+          empty
     - path: /etc/hostname
       filesystem: root
       mode: 0644

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -47,14 +47,15 @@ systemd:
         [Unit]
         Description=Kubelet via Hyperkube ACI
         [Service]
-        Environment="RKT_OPTS=--uuid-file-save=/var/run/kubelet-pod.uuid \
+        Environment=KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
+        Environment=KUBELET_IMAGE_TAG=v1.6.1_coreos.0
+        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid \
           --volume=resolv,kind=host,source=/etc/resolv.conf \
           --mount volume=resolv,target=/etc/resolv.conf \
           --volume var-lib-cni,kind=host,source=/var/lib/cni \
           --mount volume=var-lib-cni,target=/var/lib/cni \
           --volume var-log,kind=host,source=/var/log \
           --mount volume=var-log,target=/var/log"
-        EnvironmentFile=/etc/kubernetes/kubelet.env
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
@@ -74,6 +75,7 @@ systemd:
           --pod-manifest-path=/etc/kubernetes/manifests \
           --allow-privileged \
           --hostname-override={{.domain_name}} \
+          --node-labels=node-role.kubernetes.io/node \
           --cluster_dns={{.k8s_dns_service_ip}} \
           --cluster_domain=cluster.local
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
@@ -100,13 +102,12 @@ storage:
             - "-LROOT"
   {{end}}
   files:
-    - path: /etc/kubernetes/kubelet.env
+    - path: /etc/kubernetes/.empty
       filesystem: root
       mode: 0644
       contents:
         inline: |
-          KUBELET_ACI=quay.io/coreos/hyperkube
-          KUBELET_VERSION=v1.6.1_coreos.0
+          empty
     - path: /etc/hostname
       filesystem: root
       mode: 0644

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -7,7 +7,7 @@ systemd:
         - name: 40-etcd-cluster.conf
           contents: |
             [Service]
-            Environment="ETCD_IMAGE_TAG=v3.1.0"
+            Environment="ETCD_IMAGE_TAG=v3.1.6"
             ExecStart=
             ExecStart=/usr/lib/coreos/etcd-wrapper gateway start \
               --listen-addr=127.0.0.1:2379 \

--- a/examples/ignition/etcd3-gateway.yaml
+++ b/examples/ignition/etcd3-gateway.yaml
@@ -7,7 +7,7 @@ systemd:
         - name: 40-etcd-cluster.conf
           contents: |
             [Service]
-            Environment="ETCD_IMAGE_TAG=v3.1.0"
+            Environment="ETCD_IMAGE_TAG=v3.1.6"
             ExecStart=
             ExecStart=/usr/lib/coreos/etcd-wrapper gateway start \
               --listen-addr=127.0.0.1:2379 \

--- a/examples/ignition/etcd3.yaml
+++ b/examples/ignition/etcd3.yaml
@@ -7,7 +7,7 @@ systemd:
         - name: 40-etcd-cluster.conf
           contents: |
             [Service]
-            Environment="ETCD_IMAGE_TAG=v3.1.0"
+            Environment="ETCD_IMAGE_TAG=v3.1.6"
             Environment="ETCD_NAME={{.etcd_name}}"
             Environment="ETCD_ADVERTISE_CLIENT_URLS=http://{{.domain_name}}:2379"
             Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=http://{{.domain_name}}:2380"

--- a/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
@@ -7,7 +7,7 @@ systemd:
         - name: 40-etcd-cluster.conf
           contents: |
             [Service]
-            Environment="ETCD_IMAGE_TAG=v3.1.0"
+            Environment="ETCD_IMAGE_TAG=v3.1.6"
             Environment="ETCD_NAME={{.etcd_name}}"
             Environment="ETCD_ADVERTISE_CLIENT_URLS=http://{{.domain_name}}:2379"
             Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=http://{{.domain_name}}:2380"

--- a/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
@@ -50,14 +50,15 @@ systemd:
         [Unit]
         Description=Kubelet via Hyperkube ACI
         [Service]
-        Environment="RKT_OPTS=--uuid-file-save=/var/run/kubelet-pod.uuid \
+        Environment=KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
+        Environment=KUBELET_IMAGE_TAG=v1.6.1_coreos.0
+        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid \
           --volume=resolv,kind=host,source=/etc/resolv.conf \
           --mount volume=resolv,target=/etc/resolv.conf \
           --volume var-lib-cni,kind=host,source=/var/lib/cni \
           --mount volume=var-lib-cni,target=/var/lib/cni \
           --volume var-log,kind=host,source=/var/log \
           --mount volume=var-log,target=/var/log"
-        EnvironmentFile=/etc/kubernetes/kubelet.env
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
@@ -78,6 +79,7 @@ systemd:
           --allow-privileged \
           --hostname-override={{.domain_name}} \
           --node-labels=master=true \
+          --node-labels=node-role.kubernetes.io/master \
           --cluster_dns={{.k8s_dns_service_ip}} \
           --cluster_domain=cluster.local
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
@@ -111,13 +113,12 @@ storage:
             - "-LROOT"
   {{end}}
   files:
-    - path: /etc/kubernetes/kubelet.env
+    - path: /etc/kubernetes/.empty
       filesystem: root
       mode: 0644
       contents:
         inline: |
-          KUBELET_ACI=quay.io/coreos/hyperkube
-          KUBELET_VERSION=v1.6.1_coreos.0
+          empty
     - path: /etc/hostname
       filesystem: root
       mode: 0644

--- a/examples/terraform/modules/profiles/cl/bootkube-worker.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/bootkube-worker.yaml.tmpl
@@ -47,14 +47,15 @@ systemd:
         [Unit]
         Description=Kubelet via Hyperkube ACI
         [Service]
-        Environment="RKT_OPTS=--uuid-file-save=/var/run/kubelet-pod.uuid \
+        Environment=KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
+        Environment=KUBELET_IMAGE_TAG=v1.6.1_coreos.0
+        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid \
           --volume=resolv,kind=host,source=/etc/resolv.conf \
           --mount volume=resolv,target=/etc/resolv.conf \
           --volume var-lib-cni,kind=host,source=/var/lib/cni \
           --mount volume=var-lib-cni,target=/var/lib/cni \
           --volume var-log,kind=host,source=/var/log \
           --mount volume=var-log,target=/var/log"
-        EnvironmentFile=/etc/kubernetes/kubelet.env
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
@@ -74,6 +75,7 @@ systemd:
           --pod-manifest-path=/etc/kubernetes/manifests \
           --allow-privileged \
           --hostname-override={{.domain_name}} \
+          --node-labels=node-role.kubernetes.io/node \
           --cluster_dns={{.k8s_dns_service_ip}} \
           --cluster_domain=cluster.local
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
@@ -100,13 +102,12 @@ storage:
             - "-LROOT"
   {{end}}
   files:
-    - path: /etc/kubernetes/kubelet.env
+    - path: /etc/kubernetes/.empty
       filesystem: root
       mode: 0644
       contents:
         inline: |
-          KUBELET_ACI=quay.io/coreos/hyperkube
-          KUBELET_VERSION=v1.6.1_coreos.0
+          empty
     - path: /etc/hostname
       filesystem: root
       mode: 0644

--- a/examples/terraform/modules/profiles/cl/bootkube-worker.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/bootkube-worker.yaml.tmpl
@@ -7,7 +7,7 @@ systemd:
         - name: 40-etcd-cluster.conf
           contents: |
             [Service]
-            Environment="ETCD_IMAGE_TAG=v3.1.0"
+            Environment="ETCD_IMAGE_TAG=v3.1.6"
             ExecStart=
             ExecStart=/usr/lib/coreos/etcd-wrapper gateway start \
               --listen-addr=127.0.0.1:2379 \

--- a/examples/terraform/modules/profiles/cl/etcd3-gateway.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/etcd3-gateway.yaml.tmpl
@@ -7,7 +7,7 @@ systemd:
         - name: 40-etcd-cluster.conf
           contents: |
             [Service]
-            Environment="ETCD_IMAGE_TAG=v3.1.0"
+            Environment="ETCD_IMAGE_TAG=v3.1.6"
             ExecStart=
             ExecStart=/usr/lib/coreos/etcd-wrapper gateway start \
               --listen-addr=127.0.0.1:2379 \

--- a/examples/terraform/modules/profiles/cl/etcd3.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/etcd3.yaml.tmpl
@@ -7,7 +7,7 @@ systemd:
         - name: 40-etcd-cluster.conf
           contents: |
             [Service]
-            Environment="ETCD_IMAGE_TAG=v3.1.0"
+            Environment="ETCD_IMAGE_TAG=v3.1.6"
             Environment="ETCD_NAME={{.etcd_name}}"
             Environment="ETCD_ADVERTISE_CLIENT_URLS=http://{{.domain_name}}:2379"
             Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=http://{{.domain_name}}:2380"


### PR DESCRIPTION
* Update self-hosted Kubernetes node labels
* Update kubelet wrapper env variables and location
* Update etcd3 from 3.1.0 to 3.1.6	