### PR TITLE
*: Prepare for v0.6.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Notable changes between releases.
 
 ## Latest
 
+## v0.6.0 (2017-04-25)
+
 * New [terraform-provider-matchbox](https://github.com/coreos/terraform-provider-matchbox) plugin for Terraform users!
 * New hosted [documentation](https://coreos.com/matchbox/docs/latest) on coreos.com
 * Add `ProfileDelete`, `GroupDelete`, `IgnitionGet` and `IgnitionDelete` gRPC endpoints

--- a/Documentation/deployment.md
+++ b/Documentation/deployment.md
@@ -20,23 +20,23 @@ Choose one of the supported installation options:
 Download the latest matchbox [release](https://github.com/coreos/matchbox/releases) to the provisioner host.
 
 ```sh
-$ wget https://github.com/coreos/matchbox/releases/download/v0.5.0/matchbox-v0.5.0-linux-amd64.tar.gz
-$ wget https://github.com/coreos/matchbox/releases/download/v0.5.0/matchbox-v0.5.0-linux-amd64.tar.gz.asc
+$ wget https://github.com/coreos/matchbox/releases/download/v0.6.0/matchbox-v0.6.0-linux-amd64.tar.gz
+$ wget https://github.com/coreos/matchbox/releases/download/v0.6.0/matchbox-v0.6.0-linux-amd64.tar.gz.asc
 ```
 
 Verify the release has been signed by the [CoreOS App Signing Key](https://coreos.com/security/app-signing-key/).
 
 ```sh
 $ gpg --keyserver pgp.mit.edu --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
-$ gpg --verify matchbox-v0.5.0-linux-amd64.tar.gz.asc matchbox-v0.5.0-linux-amd64.tar.gz
+$ gpg --verify matchbox-v0.6.0-linux-amd64.tar.gz.asc matchbox-v0.6.0-linux-amd64.tar.gz
 # gpg: Good signature from "CoreOS Application Signing Key <security@coreos.com>"
 ```
 
 Untar the release.
 
 ```sh
-$ tar xzvf matchbox-v0.5.0-linux-amd64.tar.gz
-$ cd matchbox-v0.5.0-linux-amd64
+$ tar xzvf matchbox-v0.6.0-linux-amd64.tar.gz
+$ cd matchbox-v0.6.0-linux-amd64
 ```
 
 ## Install

--- a/Documentation/dev/release.md
+++ b/Documentation/dev/release.md
@@ -8,7 +8,7 @@ This guide covers releasing new versions of matchbox.
 Create a release commit which updates old version references.
 
 ```sh
-$ export VERSION=v0.5.0
+$ export VERSION=v0.6.0
 ```
 
 ## Tag
@@ -45,27 +45,7 @@ $ make release
 Verify the reported version.
 
 ```
-./_output/matchbox-v0.5.0-linux-amd64/matchbox -version
-```
-
-## ACI
-
-Build the rkt ACI on a Linux host with `acbuild`,
-
-```sh
-$ make aci
-```
-
-Check that the listed version is correct/clean.
-
-```sh
-$ sudo rkt --insecure-options=image run matchbox.aci -- -version
-```
-
-Add the ACI to `output` for signing.
-
-```sh
-$ mv matchbox.aci _output/matchbox-$VERSION-linux-amd64.aci
+./_output/matchbox-v0.6.0-linux-amd64/matchbox -version
 ```
 
 ## Signing
@@ -74,7 +54,6 @@ Sign the release tarballs and ACI with a [CoreOS App Signing Key](https://coreos
 
 ```sh
 $ cd _output
-$ gpg2 -a --default-key FC8A365E --detach-sign matchbox-$VERSION-linux-amd64.aci
 $ gpg2 -a --default-key FC8A365E --detach-sign matchbox-$VERSION-linux-amd64.tar.gz
 $ gpg2 -a --default-key FC8A365E --detach-sign matchbox-$VERSION-darwin-amd64.tar.gz
 $ gpg2 -a --default-key FC8A365E --detach-sign matchbox-$VERSION-linux-arm.tar.gz
@@ -84,7 +63,6 @@ $ gpg2 -a --default-key FC8A365E --detach-sign matchbox-$VERSION-linux-arm64.tar
 Verify the signatures.
 
 ```sh
-$ gpg2 --verify matchbox-$VERSION-linux-amd64.aci.asc matchbox-$VERSION-linux-amd64.aci
 $ gpg2 --verify matchbox-$VERSION-linux-amd64.tar.gz.asc matchbox-$VERSION-linux-amd64.tar.gz
 $ gpg2 --verify matchbox-$VERSION-darwin-amd64.tar.gz.asc matchbox-$VERSION-darwin-amd64.tar.gz
 $ gpg2 --verify matchbox-$VERSION-linux-arm.tar.gz.asc matchbox-$VERSION-linux-arm.tar.gz
@@ -93,4 +71,4 @@ $ gpg2 --verify matchbox-$VERSION-linux-arm64.tar.gz.asc matchbox-$VERSION-linux
 
 ## Publish
 
-Upload the signed tarball(s) and ACI with the Github release. Promote the release from a `pre-release` to an official release.
+Upload the signed tarball(s) with the Github release. Promote the release from a `pre-release` to an official release.

--- a/Documentation/getting-started-rkt.md
+++ b/Documentation/getting-started-rkt.md
@@ -106,7 +106,7 @@ sudo rkt run --net=metal0:IP=172.18.0.2 \
   --volume data,kind=host,source=$PWD/examples \
   --mount volume=groups,target=/var/lib/matchbox/groups \
   --volume groups,kind=host,source=$PWD/examples/groups/etcd3 \
-  quay.io/coreos/matchbox:v0.5.0 -- -address=0.0.0.0:8080 -log-level=debug
+  quay.io/coreos/matchbox:v0.6.0 -- -address=0.0.0.0:8080 -log-level=debug
 ```
 ```sh
 sudo rkt run --net=metal0:IP=172.18.0.3 \

--- a/contrib/k8s/matchbox-deployment.yaml
+++ b/contrib/k8s/matchbox-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: matchbox
-          image: quay.io/coreos/matchbox:v0.5.0
+          image: quay.io/coreos/matchbox:v0.6.0
           env:
             - name: MATCHBOX_ADDRESS
               value: "0.0.0.0:8080"
@@ -35,12 +35,8 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/matchbox
-            - name: groups
-              mountPath: /var/lib/matchbox/groups
-            - name: profiles
-              mountPath: /var/lib/matchbox/profiles
-            - name: ignition
-              mountPath: /var/lib/matchbox/ignition
+            - name: data
+              mountPath: /var/lib/matchbox
             - name: assets
               mountPath: /var/lib/matchbox/assets
       dnsPolicy: ClusterFirst
@@ -50,12 +46,7 @@ spec:
         - name: config
           secret:
             secretName: matchbox-rpc
-        - name: groups
-          emptyDir: {}
-        - name: profiles
-          emptyDir: {}
-        - name: ignition
+        - name: data
           emptyDir: {}
         - name: assets
           emptyDir: {}
-

--- a/contrib/systemd/matchbox-for-tectonic.service
+++ b/contrib/systemd/matchbox-for-tectonic.service
@@ -4,7 +4,7 @@ Documentation=https://github.com/coreos/matchbox
 
 [Service]
 Environment="IMAGE=quay.io/coreos/matchbox"
-Environment="VERSION=v0.5.0"
+Environment="VERSION=v0.6.0"
 Environment="MATCHBOX_ADDRESS=0.0.0.0:8080"
 Environment="MATCHBOX_RPC_ADDRESS=0.0.0.0:8081"
 Environment="MATCHBOX_LOG_LEVEL=debug"

--- a/contrib/systemd/matchbox-on-coreos.service
+++ b/contrib/systemd/matchbox-on-coreos.service
@@ -4,7 +4,7 @@ Documentation=https://github.com/coreos/matchbox
 
 [Service]
 Environment="IMAGE=quay.io/coreos/matchbox"
-Environment="VERSION=v0.5.0"
+Environment="VERSION=v0.6.0"
 Environment="MATCHBOX_ADDRESS=0.0.0.0:8080"
 ExecStartPre=/usr/bin/mkdir -p /etc/matchbox
 ExecStartPre=/usr/bin/mkdir -p /var/lib/matchbox/assets


### PR DESCRIPTION
Starting in v0.6.0, we will no longer be shipping ACIs for matchbox (or dnsmasq or other contrib images). Quay.io images can be used by rkt and docker just fine. ACI build scripts are kept only for local development purposes and may be removed at a future date. cc @philips 