### PR TITLE
scripts: get CoreOS version from current release

### DIFF
--- a/scripts/get-coreos
+++ b/scripts/get-coreos
@@ -6,7 +6,13 @@ set -eou pipefail
 GPG=${GPG:-/usr/bin/gpg}
 
 CHANNEL=${1:-"stable"}
-VERSION=${2:-"1298.7.0"}
+if [[ -z "${2:-}" ]]
+then
+    CURRENT_VERSION=$( curl -s \
+	"https://$CHANNEL.release.core-os.net/amd64-usr/current/version.txt" \
+	| sed -n 's/^COREOS_VERSION=\(.*\)/\1/p' )
+fi
+VERSION=${2:-"$CURRENT_VERSION"}
 DEST_DIR=${3:-"$PWD/examples/assets"}
 DEST=$DEST_DIR/coreos/$VERSION
 BASE_URL=https://$CHANNEL.release.core-os.net/amd64-usr/$VERSION


### PR DESCRIPTION
If `$2` is not specified, fetch coreos_version string from `current` release version.  This resolves the situation where the get_coreos script has been updated to reflect current ContainerOS release, but there has not been a new Tectonic release to actually include the updated get_coreos script.  And it makes it easier to just run the script periodically without having to look up the new OS release's version.