### PR TITLE
examples: Update self-hosted Kubernetes to v1.6.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ Notable changes between releases.
 
 ## Latest
 
+### Examples
+
+* Upgrade self-hosted Kubernetes cluster examples to v1.6.2
+
 ## v0.6.0 (2017-04-25)
 
 * New [terraform-provider-matchbox](https://github.com/coreos/terraform-provider-matchbox) plugin for Terraform users!

--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes
 
-The self-hosted Kubernetes example provisions a 3 node "self-hosted" Kubernetes v1.6.1 cluster. On-host kubelets wait for an apiserver to become reachable, then yield to kubelet pods scheduled via daemonset. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run on any controller to bootstrap a temporary apiserver which schedules control plane components as pods before exiting. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
+The self-hosted Kubernetes example provisions a 3 node "self-hosted" Kubernetes v1.6.2 cluster. On-host kubelets wait for an apiserver to become reachable, then yield to kubelet pods scheduled via daemonset. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run on any controller to bootstrap a temporary apiserver which schedules control plane components as pods before exiting. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
 
 ## Requirements
 
@@ -11,11 +11,11 @@ Ensure that you've gone through the [matchbox with rkt](getting-started-rkt.md) 
 * Create the example libvirt client VMs
 * `/etc/hosts` entries for `node[1-3].example.com` (or pass custom names to `k8s-certgen`)
 
-Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.4.0 and add it somewhere on your PATH.
+Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.4.1 and add it somewhere on your PATH.
 
 ```sh
 $ bootkube version
-Version: v0.4.0
+Version: v0.4.1
 ```
 
 ## Examples
@@ -47,7 +47,7 @@ Add your SSH public key to each machine group definition [as shown](../examples/
 Use the `bootkube` tool to render Kubernetes manifests and credentials into an `--asset-dir`. Later, `bootkube` will schedule these manifests during bootstrapping and the credentials will be used to access your cluster.
 
 ```sh
-$ bootkube render --asset-dir=assets --api-servers=https://node1.example.com:443 --api-server-alt-names=DNS=node1.example.com
+$ bootkube render --asset-dir=assets --api-servers=https://node1.example.com:443 --api-server-alt-names=DNS=node1.example.com --etcd-servers=http://127.0.0.1:2379
 ```
 
 ## Containers

--- a/examples/ignition/bootkube-controller.yaml
+++ b/examples/ignition/bootkube-controller.yaml
@@ -50,8 +50,7 @@ systemd:
         [Unit]
         Description=Kubelet via Hyperkube ACI
         [Service]
-        Environment=KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-        Environment=KUBELET_IMAGE_TAG=v1.6.1_coreos.0
+        EnvironmentFile=/etc/kubernetes/kubelet.env
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid \
           --volume=resolv,kind=host,source=/etc/resolv.conf \
           --mount volume=resolv,target=/etc/resolv.conf \
@@ -78,7 +77,6 @@ systemd:
           --pod-manifest-path=/etc/kubernetes/manifests \
           --allow-privileged \
           --hostname-override={{.domain_name}} \
-          --node-labels=master=true \
           --node-labels=node-role.kubernetes.io/master \
           --cluster_dns={{.k8s_dns_service_ip}} \
           --cluster_domain=cluster.local
@@ -113,12 +111,13 @@ storage:
             - "-LROOT"
   {{end}}
   files:
-    - path: /etc/kubernetes/.empty
+    - path: /etc/kubernetes/kubelet.env
       filesystem: root
       mode: 0644
       contents:
         inline: |
-          empty
+          KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
+          KUBELET_IMAGE_TAG=v1.6.2_coreos.0
     - path: /etc/hostname
       filesystem: root
       mode: 0644
@@ -142,20 +141,20 @@ storage:
           #!/bin/bash
           # Wrapper for bootkube start
           set -e
-          mkdir -p /tmp/bootkube
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.4.0}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.4.1}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/opt/bootkube/assets}"
           exec /usr/bin/rkt run \
             --trust-keys-from-https \
             --volume assets,kind=host,source=$BOOTKUBE_ASSETS \
             --mount volume=assets,target=/assets \
-            --volume bootstrap,kind=host,source=/etc/kubernetes/manifests \
-            --mount volume=bootstrap,target=/etc/kubernetes/manifests \
-            --volume temp,kind=host,source=/tmp/bootkube \
-            --mount volume=temp,target=/tmp/bootkube \
+            --volume bootstrap,kind=host,source=/etc/kubernetes \
+            --mount volume=bootstrap,target=/etc/kubernetes \
             $RKT_OPTS \
-            ${BOOTKUBE_ACI}:${BOOTKUBE_VERSION} --net=host --exec=/bootkube -- start --asset-dir=/assets "$@"
+            ${BOOTKUBE_ACI}:${BOOTKUBE_VERSION} \
+            --net=host \
+            --dns=host \
+            --exec=/bootkube -- start --asset-dir=/assets "$@"
 
 {{ if index . "ssh_authorized_keys" }}
 passwd:

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -47,8 +47,7 @@ systemd:
         [Unit]
         Description=Kubelet via Hyperkube ACI
         [Service]
-        Environment=KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-        Environment=KUBELET_IMAGE_TAG=v1.6.1_coreos.0
+        EnvironmentFile=/etc/kubernetes/kubelet.env
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid \
           --volume=resolv,kind=host,source=/etc/resolv.conf \
           --mount volume=resolv,target=/etc/resolv.conf \
@@ -102,12 +101,13 @@ storage:
             - "-LROOT"
   {{end}}
   files:
-    - path: /etc/kubernetes/.empty
+    - path: /etc/kubernetes/kubelet.env
       filesystem: root
       mode: 0644
       contents:
         inline: |
-          empty
+          KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
+          KUBELET_IMAGE_TAG=v1.6.2_coreos.0
     - path: /etc/hostname
       filesystem: root
       mode: 0644

--- a/examples/terraform/bootkube-install/README.md
+++ b/examples/terraform/bootkube-install/README.md
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes
 
-The self-hosted Kubernetes example provisions a 3 node "self-hosted" Kubernetes v1.6.1 cluster. On-host kubelets wait for an apiserver to become reachable, then yield to kubelet pods scheduled via daemonset. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run on any controller to bootstrap a temporary apiserver which schedules control plane components as pods before exiting. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
+The self-hosted Kubernetes example provisions a 3 node "self-hosted" Kubernetes v1.6.2 cluster. On-host kubelets wait for an apiserver to become reachable, then yield to kubelet pods scheduled via daemonset. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run on any controller to bootstrap a temporary apiserver which schedules control plane components as pods before exiting. An etcd cluster backs Kubernetes and coordinates CoreOS auto-updates (enabled for disk installs).
 
 ## Requirements
 
@@ -9,17 +9,17 @@ The self-hosted Kubernetes example provisions a 3 node "self-hosted" Kubernetes 
 * 3 machines with known DNS names and MAC addresses for this example
 * Matchbox provider credentials: a `client.crt`, `client.key`, and `ca.crt`.
 
-Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.4.0 and add it somewhere on your PATH.
+Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.4.1 and add it somewhere on your PATH.
 
 ```sh
 bootkube version
-Version v0.4.0
+Version v0.4.1
 ```
 
 Use the `bootkube` tool to render Kubernetes manifests and credentials into an `--asset-dir`. Later, `bootkube` will schedule these manifests during bootstrapping and the credentials will be used to access your cluster.
 
 ```sh
-bootkube render --asset-dir=assets --api-servers=https://node1.example.com:443 --api-server-alt-names=DNS=node1.example.com
+bootkube render --asset-dir=assets --api-servers=https://node1.example.com:443 --api-server-alt-names=DNS=node1.example.com --etcd-servers=http://127.0.0.1:2379
 ```
 
 ## Infrastructure

--- a/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
@@ -50,8 +50,7 @@ systemd:
         [Unit]
         Description=Kubelet via Hyperkube ACI
         [Service]
-        Environment=KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-        Environment=KUBELET_IMAGE_TAG=v1.6.1_coreos.0
+        EnvironmentFile=/etc/kubernetes/kubelet.env
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid \
           --volume=resolv,kind=host,source=/etc/resolv.conf \
           --mount volume=resolv,target=/etc/resolv.conf \
@@ -78,7 +77,6 @@ systemd:
           --pod-manifest-path=/etc/kubernetes/manifests \
           --allow-privileged \
           --hostname-override={{.domain_name}} \
-          --node-labels=master=true \
           --node-labels=node-role.kubernetes.io/master \
           --cluster_dns={{.k8s_dns_service_ip}} \
           --cluster_domain=cluster.local
@@ -113,12 +111,13 @@ storage:
             - "-LROOT"
   {{end}}
   files:
-    - path: /etc/kubernetes/.empty
+    - path: /etc/kubernetes/kubelet.env
       filesystem: root
       mode: 0644
       contents:
         inline: |
-          empty
+          KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
+          KUBELET_IMAGE_TAG=v1.6.2_coreos.0
     - path: /etc/hostname
       filesystem: root
       mode: 0644
@@ -142,20 +141,20 @@ storage:
           #!/bin/bash
           # Wrapper for bootkube start
           set -e
-          mkdir -p /tmp/bootkube
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.4.0}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.4.1}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/opt/bootkube/assets}"
           exec /usr/bin/rkt run \
             --trust-keys-from-https \
             --volume assets,kind=host,source=$BOOTKUBE_ASSETS \
             --mount volume=assets,target=/assets \
-            --volume bootstrap,kind=host,source=/etc/kubernetes/manifests \
-            --mount volume=bootstrap,target=/etc/kubernetes/manifests \
-            --volume temp,kind=host,source=/tmp/bootkube \
-            --mount volume=temp,target=/tmp/bootkube \
+            --volume bootstrap,kind=host,source=/etc/kubernetes \
+            --mount volume=bootstrap,target=/etc/kubernetes \
             $RKT_OPTS \
-            ${BOOTKUBE_ACI}:${BOOTKUBE_VERSION} --net=host --exec=/bootkube -- start --asset-dir=/assets "$@"
+            ${BOOTKUBE_ACI}:${BOOTKUBE_VERSION} \
+            --net=host \
+            --dns=host \
+            --exec=/bootkube -- start --asset-dir=/assets "$@"
 passwd:
   users:
     - name: core

--- a/examples/terraform/modules/profiles/cl/bootkube-worker.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/bootkube-worker.yaml.tmpl
@@ -47,8 +47,7 @@ systemd:
         [Unit]
         Description=Kubelet via Hyperkube ACI
         [Service]
-        Environment=KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-        Environment=KUBELET_IMAGE_TAG=v1.6.1_coreos.0
+        EnvironmentFile=/etc/kubernetes/kubelet.env
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid \
           --volume=resolv,kind=host,source=/etc/resolv.conf \
           --mount volume=resolv,target=/etc/resolv.conf \
@@ -102,12 +101,13 @@ storage:
             - "-LROOT"
   {{end}}
   files:
-    - path: /etc/kubernetes/.empty
+    - path: /etc/kubernetes/kubelet.env
       filesystem: root
       mode: 0644
       contents:
         inline: |
-          empty
+          KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
+          KUBELET_IMAGE_TAG=v1.6.2_coreos.0
     - path: /etc/hostname
       filesystem: root
       mode: 0644

--- a/scripts/get-bootkube
+++ b/scripts/get-bootkube
@@ -4,7 +4,7 @@
 set -eu
 
 DEST=${1:-"bin"}
-VERSION="v0.4.0"
+VERSION="v0.4.1"
 
 URL="https://github.com/kubernetes-incubator/bootkube/releases/download/${VERSION}/bootkube.tar.gz"
 

--- a/tests/smoke/bootkube
+++ b/tests/smoke/bootkube
@@ -15,7 +15,7 @@ main() {
   ./scripts/libvirt create
 
   echo "bootkube render"
-  ./bin/bootkube render --asset-dir=assets --api-servers=https://node1.example.com:443 --api-server-alt-names=DNS=node1.example.com
+  ./bin/bootkube render --asset-dir=assets --api-servers=https://node1.example.com:443 --api-server-alt-names=DNS=node1.example.com --etcd-servers=http://127.0.0.1:2379
 
   for i in `seq 1 10`; do
     ssh node1.example.com -o ConnectTimeout=5 -- 'echo "Connected"' && break


### PR DESCRIPTION
Updates both the regular and terraform based self-hosted Kubernetes clusters. Jenkins tests only PXE a 3-node bare-metal cluster using the non-terraform flow for now. Terraform testing is manual and I'll report back.