### PR TITLE
examples: Update from bootkube v0.4.1 to v0.4.2

### DIFF
--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -11,11 +11,11 @@ Ensure that you've gone through the [matchbox with rkt](getting-started-rkt.md) 
 * Create the example libvirt client VMs
 * `/etc/hosts` entries for `node[1-3].example.com` (or pass custom names to `k8s-certgen`)
 
-Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.4.1 and add it somewhere on your PATH.
+Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.4.2 and add it somewhere on your PATH.
 
 ```sh
 $ bootkube version
-Version: v0.4.1
+Version: v0.4.2
 ```
 
 ## Examples

--- a/examples/ignition/bootkube-controller.yaml
+++ b/examples/ignition/bootkube-controller.yaml
@@ -142,7 +142,7 @@ storage:
           # Wrapper for bootkube start
           set -e
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.4.1}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.4.2}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/opt/bootkube/assets}"
           exec /usr/bin/rkt run \
             --trust-keys-from-https \

--- a/examples/terraform/bootkube-install/README.md
+++ b/examples/terraform/bootkube-install/README.md
@@ -9,11 +9,11 @@ The self-hosted Kubernetes example provisions a 3 node "self-hosted" Kubernetes 
 * 3 machines with known DNS names and MAC addresses for this example
 * Matchbox provider credentials: a `client.crt`, `client.key`, and `ca.crt`.
 
-Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.4.1 and add it somewhere on your PATH.
+Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.4.2 and add it somewhere on your PATH.
 
 ```sh
 bootkube version
-Version v0.4.1
+Version v0.4.2
 ```
 
 Use the `bootkube` tool to render Kubernetes manifests and credentials into an `--asset-dir`. Later, `bootkube` will schedule these manifests during bootstrapping and the credentials will be used to access your cluster.

--- a/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
@@ -142,7 +142,7 @@ storage:
           # Wrapper for bootkube start
           set -e
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.4.1}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.4.2}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/opt/bootkube/assets}"
           exec /usr/bin/rkt run \
             --trust-keys-from-https \

--- a/scripts/get-bootkube
+++ b/scripts/get-bootkube
@@ -4,7 +4,7 @@
 set -eu
 
 DEST=${1:-"bin"}
-VERSION="v0.4.1"
+VERSION="v0.4.2"
 
 URL="https://github.com/kubernetes-incubator/bootkube/releases/download/${VERSION}/bootkube.tar.gz"
 


### PR DESCRIPTION
* Contains a few fixes to bootkube logging and checkpointing