### PR TITLE
scripts/libvirt: Allow QEMU/KVM disk size to be customized

### DIFF
--- a/scripts/libvirt
+++ b/scripts/libvirt
@@ -3,6 +3,7 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 VM_MEMORY=${VM_MEMORY:-1024}
+VM_DISK=${VM_DISK:-10}
 
 source "${DIR}/common.sh"
 
@@ -43,7 +44,7 @@ function usage {
   echo -e "\tdestroy\t\tdestroy the QEMU/KVM nodes"
 }
 
-COMMON_VIRT_OPTS="--memory=$VM_MEMORY --vcpus=1 --pxe --disk pool=default,size=6 --os-type=linux --os-variant=generic --noautoconsole --events on_poweroff=preserve"
+COMMON_VIRT_OPTS="--memory=${VM_MEMORY} --vcpus=1 --pxe --disk pool=default,size=${VM_DISK} --os-type=linux --os-variant=generic --noautoconsole --events on_poweroff=preserve"
 
 function create_docker {
   virt-install --name $NODE1_NAME --network=bridge:docker0,mac=$NODE1_MAC $COMMON_VIRT_OPTS --boot=hd,network


### PR DESCRIPTION
Create QEMU/KVM VMs with more disk or RAM than the defaults.

```
export VM_RAM=2048; export VM_DISK=12; sudo -E ./scripts/libvirt create
```