### PR TITLE
contrib/rpm: Fixing the source URL format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ bin/
 _output/
 tools/
 contrib/registry/data
+contrib/rpm/*.tar.gz

--- a/contrib/rpm/matchbox.spec
+++ b/contrib/rpm/matchbox.spec
@@ -8,7 +8,8 @@ Release:	2%{?dist}
 Summary:	Network boot and provision CoreOS machines
 License:	ASL 2.0
 URL:		https://%{import_path}
-Source0:	https://%{import_path}/archive/v%{version}.tar.gz
+Source0:        https://%{import_path}/archive/v%{version}/%{name}-%{version}.tar.gz
+
 
 BuildRequires: golang
 BuildRequires: systemd
@@ -28,9 +29,7 @@ ExclusiveArch: %{go_arches}
 BuildRequires: compiler(golang)
 
 %prep
-%setup
-# tarball has <repo>-<version> top level dir, not <name>-<version>
-#%setup -q -n %{repo}-%{version}
+%setup -q -n %{repo}-%{version}
 
 %build
 # create a Go workspace with a symlink to builddir source


### PR DESCRIPTION
Fixing the source URL format to confirm to more normative rpmbuild
standards and to allow for proper use of spectool/rpmspectool.  This
change now produces a proper archive with the name and version number
used.