### PR TITLE
Jenkinsfile,tests: Add etcd3-terraform cluster to pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,10 +9,9 @@ parallel (
   etcd3: {
     node('fedora && bare-metal') {
       stage('etcd3') {
-        timeout(time:3, unit:'MINUTES') {
+        timeout(time:5, unit:'MINUTES') {
           checkout scm
           sh '''#!/bin/bash -e
-          cat /etc/os-release
           export ASSETS_DIR=~/assets; ./tests/smoke/etcd3
           '''
         }
@@ -25,7 +24,6 @@ parallel (
         timeout(time:12, unit:'MINUTES') {
           checkout scm          
           sh '''#!/bin/bash -e
-          cat /etc/os-release
           export ASSETS_DIR=~/assets; ./tests/smoke/k8s
           '''
         }
@@ -38,9 +36,20 @@ parallel (
         timeout(time:12, unit:'MINUTES') {
           checkout scm          
           sh '''#!/bin/bash -e
-          cat /etc/os-release
           chmod 600 ./tests/smoke/fake_rsa
           export ASSETS_DIR=~/assets; ./tests/smoke/bootkube
+          '''
+        }
+      }
+    }
+  },
+  "etcd3-terraform": {
+    node('fedora && bare-metal') {
+      stage('etcd3-terraform') {
+        timeout(time:8, unit:'MINUTES') {
+          checkout scm
+          sh '''#!/bin/bash -e
+          export ASSETS_DIR=~/assets; export CONFIG_DIR=~/matchbox/examples/etc/matchbox; ./tests/smoke/etcd3-terraform
           '''
         }
       }

--- a/scripts/devnet
+++ b/scripts/devnet
@@ -14,6 +14,7 @@ COREOS_VERSION=1298.7.0
 MATCHBOX_ARGS=""
 
 ASSETS_DIR="${ASSETS_DIR:-$PWD/examples/assets}"
+CONFIG_DIR="${CONFIG_DIR:-$PWD/examples/etc/matchbox}"
 
 if [ "$EUID" -ne 0 ]
   then echo "Please run as root"
@@ -87,10 +88,10 @@ function create {
     --trust-keys-from-https \
     --net=metal0:IP=172.18.0.2 \
     --mount volume=config,target=/etc/matchbox \
-    --volume config,kind=host,source=$PWD/examples/etc/matchbox,readOnly=true \
+    --volume config,kind=host,source=$CONFIG_DIR,readOnly=true \
     --mount volume=data,target=/var/lib/matchbox \
     $DATA_MOUNT \
-    quay.io/coreos/matchbox:c8af40108fb06f345a5fdae915874b0b1b606e1a -- -address=0.0.0.0:8080 -log-level=debug $MATCHBOX_ARGS
+    quay.io/coreos/matchbox:v0.6.0 -- -address=0.0.0.0:8080 -log-level=debug $MATCHBOX_ARGS
 
   echo "Starting dnsmasq to provide DHCP/TFTP/DNS services"
   rkt rm --uuid-file=/var/run/dnsmasq-pod.uuid > /dev/null 2>&1

--- a/tests/smoke/etcd3-terraform
+++ b/tests/smoke/etcd3-terraform
@@ -8,7 +8,13 @@ main() {
   cleanup
   trap cleanup EXIT
 
-  ./scripts/devnet create etcd3
+  ./scripts/devnet create
+  
+  pushd examples/terraform/etcd3-install
+  terraform get
+  terraform apply -var-file $DIR/etcd3.tfvars
+  popd 
+
   ./scripts/libvirt create
 
   until etcd "node1.example.com" \

--- a/tests/smoke/etcd3.tfvars
+++ b/tests/smoke/etcd3.tfvars
@@ -1,0 +1,3 @@
+matchbox_http_endpoint = "http://matchbox.example.com:8080"
+matchbox_rpc_endpoint = "matchbox.example.com:8081"
+ssh_authorized_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDPQFdwVLr+alsWIgYRz9OdqDhnx9jjuFbkdSdpqq4gd9uZApYlivMDD4UgjFazQpezx8DiNhu9ym7i6LgAcdwi+10hE4L9yoJv9uBgbBxOAd65znqLqF91NtV4mlKP5YfJtR7Ehs+pTB+IIC+o5veDbPn+BYgDMJ2x7Osbn1/gFSDken/yoOFbYbRMGMfVEQYjJzC4r/qCKH0bl/xuVNLxf9FkWSTCcQFKGOndwuGITDkshD4r2Kk8gUddXPxoahBv33/2QH0CY5zbKYjhgN6I6WtwO+O1uJwtNeV1AGhYjurdd60qggNwx+W7623uK3nIXvJd3hzDO8u5oa53/tIL fake-test-key"


### PR DESCRIPTION
* Test PXE booting the Terraform-based etcd3 cluster in parallel with other clusters

This requires a few additions to executors (bc its the first terraform-based example):
* Install terraform v0.9+
* Add a .terraformrc file which points to a `terraform-provider-matchbox` binary
* Add the matchbox fake/testing TLS certs in ~/.matchbox

rel #508