### PR TITLE
Add support for OEM images

### DIFF
--- a/examples/terraform/bootkube-install/cluster.tf
+++ b/examples/terraform/bootkube-install/cluster.tf
@@ -20,5 +20,8 @@ module "cluster" {
   # bootkube assets
   k8s_domain_name               = "${var.k8s_domain_name}"
   asset_dir                     = "${var.asset_dir}"
+
+  # Optional
+  container_linux_oem           = "${var.container_linux_oem}"
   experimental_self_hosted_etcd = "${var.experimental_self_hosted_etcd}"
 }

--- a/examples/terraform/bootkube-install/terraform.tfvars.example
+++ b/examples/terraform/bootkube-install/terraform.tfvars.example
@@ -19,4 +19,5 @@ k8s_domain_name = "cluster.example.com"
 asset_dir = "assets"
 
 # Optional
+# container_linux_oem = ""
 # experimental_self_hosted_etcd = "true"

--- a/examples/terraform/bootkube-install/variables.tf
+++ b/examples/terraform/bootkube-install/variables.tf
@@ -97,6 +97,12 @@ variable "k8s_etcd_service_ip" {
   description = "Kubernetes service IP for self-hosted etcd, if enabled (must be within service_cidr)"
 }
 
+variable "container_linux_oem" {
+  type        = "string"
+  default     = ""
+  description = "Specify an OEM image id to use as base for the installation (e.g. ami, vmware_raw, xen) or leave blank for the default image"
+}
+
 variable "experimental_self_hosted_etcd" {
   default     = "false"
   description = "Create self-hosted etcd cluster as pods on Kubernetes, instead of on-hosts"

--- a/examples/terraform/etcd3-install/etcd3.tf
+++ b/examples/terraform/etcd3-install/etcd3.tf
@@ -15,6 +15,7 @@ resource "matchbox_group" "default" {
   metadata {
     container_linux_channel = "stable"
     container_linux_version = "1298.7.0"
+    container_linux_oem     = "${var.container_linux_oem}"
     ignition_endpoint       = "${var.matchbox_http_endpoint}/ignition"
     baseurl                 = "${var.matchbox_http_endpoint}/assets/coreos"
     ssh_authorized_key      = "${var.ssh_authorized_key}"

--- a/examples/terraform/etcd3-install/terraform.tfvars.example
+++ b/examples/terraform/etcd3-install/terraform.tfvars.example
@@ -1,3 +1,6 @@
 matchbox_http_endpoint = "http://matchbox.example.com:8080"
 matchbox_rpc_endpoint = "matchbox.example.com:8081"
 # ssh_authorized_key = "ADD ME"
+
+# Optional
+# container_linux_oem = ""

--- a/examples/terraform/etcd3-install/variables.tf
+++ b/examples/terraform/etcd3-install/variables.tf
@@ -12,3 +12,9 @@ variable "ssh_authorized_key" {
   type        = "string"
   description = "SSH public key to set as an authorized_key on machines"
 }
+
+variable "container_linux_oem" {
+  type = "string"
+  default = ""
+  description = "Specify an OEM image id to use as base for the installation (e.g. ami, vmware_raw, xen) or leave blank for the default image"
+}

--- a/examples/terraform/modules/bootkube/groups.tf
+++ b/examples/terraform/modules/bootkube/groups.tf
@@ -12,6 +12,7 @@ resource "matchbox_group" "container-linux-install" {
   metadata {
     container_linux_channel = "${var.container_linux_channel}"
     container_linux_version = "${var.container_linux_version}"
+    container_linux_oem     = "${var.container_linux_oem}"
     ignition_endpoint       = "${var.matchbox_http_endpoint}/ignition"
     baseurl                 = "${var.matchbox_http_endpoint}/assets/coreos"
     ssh_authorized_key      = "${var.ssh_authorized_key}"

--- a/examples/terraform/modules/bootkube/variables.tf
+++ b/examples/terraform/modules/bootkube/variables.tf
@@ -92,6 +92,12 @@ variable "k8s_etcd_service_ip" {
   description = "Kubernetes service IP for self-hosted etcd, if enabled (must be within service_cidr)"
 }
 
+variable "container_linux_oem" {
+  type        = "string"
+  default     = ""
+  description = "Specify an OEM image id to use as base for the installation (e.g. ami, vmware_raw, xen) or leave blank for the default image"
+}
+
 variable "experimental_self_hosted_etcd" {
   default     = "false"
   description = "Create self-hosted etcd cluster as pods on Kubernetes, instead of on-hosts"

--- a/examples/terraform/modules/profiles/cl/container-linux-install.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/container-linux-install.yaml.tmpl
@@ -21,7 +21,7 @@ storage:
         inline: |
           #!/bin/bash -ex
           curl "{{.ignition_endpoint}}?{{.request.raw_query}}&os=installed" -o ignition.json
-          coreos-install -d /dev/sda -C {{.container_linux_channel}} -V {{.container_linux_version}} -i ignition.json {{if index . "baseurl"}}-b {{.baseurl}}{{end}}
+          coreos-install -d /dev/sda -C {{.container_linux_channel}} -V {{.container_linux_version}} -i ignition.json {{if index . "baseurl"}}-b {{.baseurl}}{{end}} {{if index . "container_linux_oem"}}-o {{.container_linux_oem}}{{end}}
           udevadm settle
           systemctl reboot
 passwd:

--- a/scripts/get-coreos
+++ b/scripts/get-coreos
@@ -1,6 +1,9 @@
 #!/bin/bash
 # USAGE: ./scripts/get-coreos
 # USAGE: ./scripts/get-coreos channel version dest
+#
+# ENV VARS:
+# - OEM_ID - specify OEM image id to download, alongside the default one
 set -eou pipefail
 
 GPG=${GPG:-/usr/bin/gpg}
@@ -8,6 +11,7 @@ GPG=${GPG:-/usr/bin/gpg}
 CHANNEL=${1:-"stable"}
 VERSION=${2:-"1298.7.0"}
 DEST_DIR=${3:-"$PWD/examples/assets"}
+OEM_ID=${OEM_ID:-""}
 DEST=$DEST_DIR/coreos/$VERSION
 BASE_URL=https://$CHANNEL.release.core-os.net/amd64-usr/$VERSION
 
@@ -20,6 +24,16 @@ fi
 if [ ! -d "$DEST" ]; then
   echo "Creating directory $DEST"
   mkdir -p $DEST
+fi
+
+if [[ -n "${OEM_ID}" ]]; then
+  IMAGE_NAME="coreos_production_${OEM_ID}_image.bin.bz2"
+
+  # check if the oem version exists based on the header response
+  if ! curl -s -I $BASE_URL/$IMAGE_NAME | grep -q -E '^HTTP/[0-9.]+ [23][0-9][0-9]' ; then
+    echo "OEM version not found"
+    exit 1
+  fi
 fi
 
 echo "Downloading CoreOS $CHANNEL $VERSION images and sigs to $DEST"
@@ -46,7 +60,20 @@ curl -# $BASE_URL/coreos_production_image.bin.bz2 -o $DEST/coreos_production_ima
 echo "coreos_production_image.bin.bz2.sig"
 curl -# $BASE_URL/coreos_production_image.bin.bz2.sig -o $DEST/coreos_production_image.bin.bz2.sig
 
+# Install oem image
+if [[ -n "${IMAGE_NAME-}" ]]; then
+  echo $IMAGE_NAME
+  curl -# $BASE_URL/$IMAGE_NAME -o $DEST/$IMAGE_NAME
+  echo "$IMAGE_NAME.sig"
+  curl -# $BASE_URL/$IMAGE_NAME.sig -o $DEST/$IMAGE_NAME.sig
+fi
+
 # verify signatures
 $GPG --verify $DEST/coreos_production_pxe.vmlinuz.sig
 $GPG --verify $DEST/coreos_production_pxe_image.cpio.gz.sig
 $GPG --verify $DEST/coreos_production_image.bin.bz2.sig
+
+# verify oem signature
+if [[ -n "${IMAGE_NAME-}" ]]; then
+  $GPG --verify $DEST/$IMAGE_NAME.sig
+fi


### PR DESCRIPTION
Currently, when using `terraform`, the setup is using a generic image which can cause issues on some platforms. Common problem is the lack of `VM Guest Tools`, when installing on a VMware platform.

This PR adds the ability to fetch OEM images with `get-coreos` and allows a user to specify an oem image in `terraform.tfvars`.