### PR TITLE
examples: Add NoSchedule taint to bootkube controllers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Notable changes between releases.
 ### Examples
 
 * Upgrade self-hosted Kubernetes cluster examples to v1.6.2
+* Add NoSchedule taint to self-hosted Kubernetes controllers
 
 ## v0.6.0 (2017-04-25)
 

--- a/examples/ignition/bootkube-controller.yaml
+++ b/examples/ignition/bootkube-controller.yaml
@@ -78,6 +78,7 @@ systemd:
           --allow-privileged \
           --hostname-override={{.domain_name}} \
           --node-labels=node-role.kubernetes.io/master \
+          --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
           --cluster_dns={{.k8s_dns_service_ip}} \
           --cluster_domain=cluster.local
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid

--- a/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
@@ -83,6 +83,7 @@ systemd:
           --allow-privileged \
           --hostname-override={{.domain_name}} \
           --node-labels=node-role.kubernetes.io/master \
+          --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
           --cluster_dns={{.k8s_dns_service_ip}} \
           --cluster_domain=cluster.local
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid


### PR DESCRIPTION
I noticed a difference btw these examples and bootkube examples is that bootkube disables workload scheduling on controllers as of Kubernetes v1.6. Let's do the same.

*Note: This means clusters must have at least 1 controller and 1 worker to be useful.*