### PR TITLE
Organize README examples listing and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
 # matchbox [![Build Status](https://travis-ci.org/coreos/matchbox.svg?branch=master)](https://travis-ci.org/coreos/matchbox) [![GoDoc](https://godoc.org/github.com/coreos/matchbox?status.png)](https://godoc.org/github.com/coreos/matchbox) [![Docker Repository on Quay](https://quay.io/repository/coreos/matchbox/status "Docker Repository on Quay")](https://quay.io/repository/coreos/matchbox) [![IRC](https://img.shields.io/badge/irc-%23coreos-449FD8.svg)](https://botbot.me/freenode/coreos)
 
-Network boot and provision Container Linux clusters on virtual or physical hardware.
-
 **Announcement**: Matchbox [v0.6.0](https://github.com/coreos/matchbox/releases) is released with a new [Matchbox Terraform Provider][terraform] and [tutorial](Documentation/getting-started.md).
 
-## matchbox
-
-`matchbox` is a service that matches machines (based on labels like MAC, UUID, etc.) to profiles to PXE boot and provision Container Linux clusters. Profiles specify the kernel/initrd, kernel arguments, iPXE config, GRUB config, [Container Linux Config][cl-config], [Cloud-Config][cloud-config], or other configs a machine should use. Matchbox can be [installed](Documentation/deployment.md) as a binary, RPM, container image, or deployed on a Kubernetes cluster and it provides an authenticated gRPC API for clients like [terraform][terraform].
+`matchbox` is a service that matches bare-metal machines (based on labels like MAC, UUID, etc.) to profiles to PXE boot and provision Container Linux clusters. Profiles specify the kernel/initrd, kernel arguments, iPXE config, GRUB config, [Container Linux Config][cl-config], [Cloud-Config][cloud-config], or other configs a machine should use. Matchbox can be [installed](Documentation/deployment.md) as a binary, RPM, container image, or deployed on a Kubernetes cluster and it provides an authenticated gRPC API for clients like [terraform][terraform].
 
 * [Documentation][docs]
 * [matchbox Service](Documentation/matchbox.md)
@@ -16,8 +12,7 @@ Network boot and provision Container Linux clusters on virtual or physical hardw
     * [Container Linux Config][cl-config]
     * [Cloud-Config][cloud-config]
 * [Configuration](Documentation/config.md)
-* [HTTP API](Documentation/api.md)
-* [gRPC API](https://godoc.org/github.com/coreos/matchbox/matchbox/client)
+* [HTTP API](Documentation/api.md) / [gRPC API](https://godoc.org/github.com/coreos/matchbox/matchbox/client)
 * [Background: Machine Lifecycle](Documentation/machine-lifecycle.md)
 * [Background: PXE Booting](Documentation/network-booting.md)
 
@@ -40,22 +35,33 @@ Local QEMU/KVM
 
 ### Example Clusters
 
-Network boot the [examples](examples) with [QEMU/KVM](scripts/README.md#libvirt) VMs to try them on your Linux laptop.
+Create [example](examples) clusters on-premise or locally with [QEMU/KVM](scripts/README.md#libvirt).
 
-* Multi-node [self-hosted](Documentation/bootkube.md) Kubernetes cluster
-* [Upgrading](Documentation/bootkube-upgrades.md) self-hosted Kubernetes clusters
-* Multi-node [Kubernetes cluster](Documentation/kubernetes.md)
-* Multi-node [rktnetes](Documentation/rktnetes.md) cluster (i.e. Kubernetes with rkt as the container runtime)
+**Terraform-based**
+
+* [simple-install](Documentation/getting-started.md) - Install Container Linux with an SSH key on all machines (beginner)
+* [etcd3](examples/terraform/etcd3-install/README.md) - Install a 3-node etcd3 cluster
+* [Kubernetes](examples/terraform/bootkube-install/README.md) - Install a 3-node self-hosted Kubernetes v1.6.2 cluster
+* Terraform [Modules](examples/terraform/modules) - Re-usable Terraform Modules
+
+**Manual**
+
+* [etcd3](Documentation/getting-started-rkt.md) - Install a 3-node etcd3 cluster
+* [Kubernetes](Documentation/bootkube.md) - Install a 3-node self-hosted Kubernetes v1.6.2 cluster
+* Static [Kubernetes](Documentation/kubernetes.md) (discouraged, static systemd units)
+* Static [rktnetes](Documentation/rktnetes.md) (discouraged, static systemd units)
 
 ## Contrib
 
 * [dnsmasq](contrib/dnsmasq/README.md) - Run DHCP, TFTP, and DNS services with docker or rkt
+* [squid](contrib/squid/README.md) - Run a transparent cache proxy
+* [terraform-provider-matchbox](https://github.com/coreos/terraform-provider-matchbox) - Terraform plugin which supports "matchbox" provider
 
 ## Enterprise
 
 [Tectonic](https://coreos.com/tectonic/) is the enterprise-ready Kubernetes offering from CoreOS (free for 10 nodes!). The [Tectonic Installer](https://coreos.com/tectonic/docs/latest/install/bare-metal/#4-tectonic-installer) app integrates directly with `matchbox` through its gRPC API to provide a rich graphical client for populating `matchbox` with machine configs.
 
-Learn more from our [docs](https://coreos.com/tectonic/docs/latest/) or [blog](https://coreos.com/blog/tectonic-1-5-2.html).
+Learn more from our [docs](https://coreos.com/tectonic/docs/latest/) or [blog](https://coreos.com/blog/announcing-tectonic-1.6).
 
 ![Tectonic Installer](Documentation/img/tectonic-installer.png)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,24 @@
-
 # Examples
 
-These examples network boot and provision machines into Container Linux clusters using `matchbox`. You can re-use their profiles to provision your own physical machines.
+Matchbox automates network booting and provisioning of clusters. These examples show how to use matchbox on-premise or locally with [QEMU/KVM](scripts/README.md#libvirt).
+
+## Terraform Examples
+
+These examples use [Terraform](https://www.terraform.io/intro/) as a client to Matchbox.
+
+| Name                          | Description                   |
+|-------------------------------|-------------------------------|
+| [simple-install](terraform/simple-install) | Install Container Linux with an SSH key |
+| [etcd3-install](terraform/etcd3-install) | Install a 3-node etcd3 cluster |
+| [bootkube-install](terraform/bootkube-install) | Install a 3-node self-hosted Kubernetes v1.6.2 cluster |
+
+### Customization
+
+You are encouraged to look through the examples and Terraform modules. Implement your own profiles or package them as modules to meet your needs. We've just provided a starting point. Learn more about [matchbox](../Documentation/matchbox.md) and [Container Linux configs](../Documentation/container-linux-config.md).
+
+## Manual Examples
+
+These examples mount raw Matchbox objects into a Matchbox server's `/var/lib/matchbox/` directory.
 
 | Name       | Description | CoreOS Version | FS | Docs | 
 |------------|-------------|----------------|----|-----------|
@@ -17,19 +34,9 @@ These examples network boot and provision machines into Container Linux clusters
 | bootkube | iPXE boot a self-hosted Kubernetes cluster (with bootkube) | stable/1298.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
 | bootkube-install | Install a self-hosted Kubernetes cluster (with bootkube) | stable/1298.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
 
-## Tutorials
+### Customization
 
-Get started running `matchbox` on your Linux machine to network boot and provision clusters of VMs or physical hardware.
-
-* [Getting Started](../Documentation/getting-started.md)
-	* [matchbox with rkt](../Documentation/getting-started-rkt.md)
-	* [matchbox with Docker](../Documentation/getting-started-docker.md)
-* [Kubernetes (static manifests)](../Documentation/kubernetes.md)
-* [Kubernetes (rktnetes)](../Documentation/rktnetes.md)
-* [Kubernetes (self-hosted)](../Documentation/bootkube.md)
-* [Lab Examples](https://github.com/dghubble/metal)
-
-## Autologin
+#### Autologin
 
 Example profiles pass the `coreos.autologin` kernel argument. This skips the password prompt for development and troubleshooting and should be removed **before production**.
 
@@ -46,8 +53,8 @@ Example groups allow `ssh_authorized_keys` to be added for the `core` user as me
         }
     }
 
-## Conditional Variables
+#### Conditional Variables
 
-### "pxe"
+**"pxe"**
 
 Some examples check the `pxe` variable to determine whether to create a `/dev/sda1` filesystem and partition for PXEing with `root=/dev/sda1` ("pxe":"true") or to write files to the existing filesystem on `/dev/disk/by-label/ROOT` ("pxe":"false").

--- a/examples/terraform/modules/README.md
+++ b/examples/terraform/modules/README.md
@@ -1,15 +1,6 @@
-# Examples with Terraform
+# Terraform Modules
 
-Matchbox automates network booting and provisioning Container Linux clusters. These examples show how to use matchbox with Teraform to create official reference clusters.
-
-| Name                          | Description                   |
-|-------------------------------|-------------------------------|
-| [etcd3-install](etcd3-install) | Install a 3-node etcd3 cluster |
-| [bootkube-install](bootkube-install) | Install a 3-node self-hosted Kubernetes v1.6.2 cluster | 
-
-## Modules
-
-Matchbox also provides Terraform [modules](https://www.terraform.io/docs/modules/usage.html) you can use directly within your own Terraform configs. Modules are updated regularly so it is **recommended** that you pin the module version (e.g. `ref=sha`) to keep your configs deterministic.
+Matchbox provides Terraform [modules](https://www.terraform.io/docs/modules/usage.html) you can re-use directly within your own Terraform configs. Modules are updated regularly so it is **recommended** that you pin the module version (e.g. `ref=sha`) to keep your configs deterministic.
 
 ```hcl
 module "profiles" {


### PR DESCRIPTION
Highlight new terraform-based examples more prominently rather than burying them under the `examples/terraform` subfolder.