### PR TITLE
examples: Update Kubernetes to use bootkube v0.4.3

### DIFF
--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -11,11 +11,11 @@ Ensure that you've gone through the [matchbox with rkt](getting-started-rkt.md) 
 * Create the example libvirt client VMs
 * `/etc/hosts` entries for `node[1-3].example.com` (or pass custom names to `k8s-certgen`)
 
-Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.4.2 and add it somewhere on your PATH.
+Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.4.3 and add it somewhere on your PATH.
 
 ```sh
 $ bootkube version
-Version: v0.4.2
+Version: v0.4.3
 ```
 
 ## Examples

--- a/examples/ignition/bootkube-controller.yaml
+++ b/examples/ignition/bootkube-controller.yaml
@@ -143,7 +143,7 @@ storage:
           # Wrapper for bootkube start
           set -e
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.4.2}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.4.3}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/opt/bootkube/assets}"
           exec /usr/bin/rkt run \
             --trust-keys-from-https \

--- a/examples/terraform/bootkube-install/variables.tf
+++ b/examples/terraform/bootkube-install/variables.tf
@@ -97,6 +97,12 @@ variable "k8s_etcd_service_ip" {
   description = "Kubernetes service IP for self-hosted etcd, if enabled (must be within service_cidr)"
 }
 
+variable "k8s_bootstrap_etcd_service_ip" {
+  type        = "string"
+  default     = "10.3.0.200"
+  description = "Kubernetes service IP for bootstrap self-hosted etcd, if enabled (must be within service_cidr)"
+}
+
 variable "container_linux_oem" {
   type        = "string"
   default     = ""

--- a/examples/terraform/modules/bootkube/bootkube.tf
+++ b/examples/terraform/modules/bootkube/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/dghubble/bootkube-terraform.git?ref=bf57fb4de14638db481897b1c9228e974c2db90a"
+  source = "git::https://github.com/dghubble/bootkube-terraform.git?ref=209da6d09b1cadad655eee56d63ff0dc750c5bda"
 
   cluster_name                  = "${var.cluster_name}"
   api_servers                   = ["${var.k8s_domain_name}"]
@@ -11,5 +11,6 @@ module "bootkube" {
   kube_apiserver_service_ip     = "${var.k8s_apiserver_service_ip}"
   kube_dns_service_ip           = "${var.k8s_dns_service_ip}"
   kube_etcd_service_ip          = "${var.k8s_etcd_service_ip}"
+  kube_bootstrap_etcd_service_ip = "${var.k8s_bootstrap_etcd_service_ip}"
   experimental_self_hosted_etcd = "${var.experimental_self_hosted_etcd}"
 }

--- a/examples/terraform/modules/bootkube/variables.tf
+++ b/examples/terraform/modules/bootkube/variables.tf
@@ -92,6 +92,12 @@ variable "k8s_etcd_service_ip" {
   description = "Kubernetes service IP for self-hosted etcd, if enabled (must be within service_cidr)"
 }
 
+variable "k8s_bootstrap_etcd_service_ip" {
+  type        = "string"
+  default     = "10.3.0.200"
+  description = "Kubernetes service IP for bootstrap self-hosted etcd, if enabled (must be within service_cidr)"
+}
+
 variable "container_linux_oem" {
   type        = "string"
   default     = ""

--- a/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
@@ -154,7 +154,7 @@ storage:
           [ -d /opt/bootkube/assets/experimental/manifests ] && mv /opt/bootkube/assets/experimental/manifests/* /opt/bootkube/assets/manifests && rm -r /opt/bootkube/assets/experimental/manifests
           [ -d /opt/bootkube/assets/experimental/bootstrap-manifests ] && mv /opt/bootkube/assets/experimental/bootstrap-manifests/* /opt/bootkube/assets/bootstrap-manifests && rm -r /opt/bootkube/assets/experimental/bootstrap-manifests
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.4.2}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.4.3}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/opt/bootkube/assets}"
           exec /usr/bin/rkt run \
             --trust-keys-from-https \

--- a/scripts/get-bootkube
+++ b/scripts/get-bootkube
@@ -4,7 +4,7 @@
 set -eu
 
 DEST=${1:-"bin"}
-VERSION="v0.4.2"
+VERSION="v0.4.3"
 
 URL="https://github.com/kubernetes-incubator/bootkube/releases/download/${VERSION}/bootkube.tar.gz"
 


### PR DESCRIPTION
* Update bootkube cluster example to use bootkube v0.4.3 for render and start
* Update terraform-based bootkube-install cluster example to use v0.4.3 for start and terraform ([assets](https://github.com/dghubble/bootkube-terraform/pull/1))
