### PR TITLE
Calculate Kubernetes service IPs based on the service CIDR

### DIFF
--- a/examples/terraform/bootkube-install/variables.tf
+++ b/examples/terraform/bootkube-install/variables.tf
@@ -74,33 +74,12 @@ variable "pod_cidr" {
 }
 
 variable "service_cidr" {
-  description = "CIDR IP range to assign Kubernetes services"
+  description = <<EOD
+CIDR IP range to assign Kubernetes services.
+The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for kube-dns, the 15th IP will be reserved for self-hosted etcd, and the 200th IP will be reserved for bootstrap self-hosted etcd.
+EOD
   type        = "string"
   default     = "10.3.0.0/16"
-}
-
-variable "k8s_apiserver_service_ip" {
-  description = "Kubernetes service IP for kube-apiserver (must be within service_cidr)"
-  type        = "string"
-  default     = "10.3.0.1"
-}
-
-variable "k8s_dns_service_ip" {
-  description = "Kubernetes service IP for kube-dns (must be within server_cidr)"
-  type        = "string"
-  default     = "10.3.0.10"
-}
-
-variable "k8s_etcd_service_ip" {
-  type        = "string"
-  default     = "10.3.0.15"
-  description = "Kubernetes service IP for self-hosted etcd, if enabled (must be within service_cidr)"
-}
-
-variable "k8s_bootstrap_etcd_service_ip" {
-  type        = "string"
-  default     = "10.3.0.200"
-  description = "Kubernetes service IP for bootstrap self-hosted etcd, if enabled (must be within service_cidr)"
 }
 
 variable "container_linux_oem" {

--- a/examples/terraform/modules/bootkube/bootkube.tf
+++ b/examples/terraform/modules/bootkube/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/dghubble/bootkube-terraform.git?ref=209da6d09b1cadad655eee56d63ff0dc750c5bda"
+  source = "git::https://github.com/dghubble/bootkube-terraform.git?ref=368f09bcf189e1fe9d6185e1795e3c4bf8b1fab4"
 
   cluster_name                  = "${var.cluster_name}"
   api_servers                   = ["${var.k8s_domain_name}"]
@@ -8,9 +8,5 @@ module "bootkube" {
   asset_dir                     = "${var.asset_dir}"
   pod_cidr                      = "${var.pod_cidr}"
   service_cidr                  = "${var.service_cidr}"
-  kube_apiserver_service_ip     = "${var.k8s_apiserver_service_ip}"
-  kube_dns_service_ip           = "${var.k8s_dns_service_ip}"
-  kube_etcd_service_ip          = "${var.k8s_etcd_service_ip}"
-  kube_bootstrap_etcd_service_ip = "${var.k8s_bootstrap_etcd_service_ip}"
   experimental_self_hosted_etcd = "${var.experimental_self_hosted_etcd}"
 }

--- a/examples/terraform/modules/bootkube/groups.tf
+++ b/examples/terraform/modules/bootkube/groups.tf
@@ -34,8 +34,8 @@ resource "matchbox_group" "controller" {
     etcd_name            = "${element(var.controller_names, count.index)}"
     etcd_initial_cluster = "${join(",", formatlist("%s=http://%s:2380", var.controller_names, var.controller_domains))}"
     etcd_on_host         = "${var.experimental_self_hosted_etcd ? "false" : "true"}"
-    k8s_dns_service_ip   = "${var.k8s_dns_service_ip}"
-    k8s_etcd_service_ip  = "${var.k8s_etcd_service_ip}"
+    k8s_dns_service_ip   = "${module.bootkube.kube_dns_service_ip}"
+    k8s_etcd_service_ip  = "${module.bootkube.etcd_service_ip}"
     ssh_authorized_key   = "${var.ssh_authorized_key}"
   }
 }
@@ -54,8 +54,8 @@ resource "matchbox_group" "worker" {
     domain_name         = "${element(var.worker_domains, count.index)}"
     etcd_endpoints      = "${join(",", formatlist("%s:2379", var.controller_domains))}"
     etcd_on_host        = "${var.experimental_self_hosted_etcd ? "false" : "true"}"
-    k8s_dns_service_ip  = "${var.k8s_dns_service_ip}"
-    k8s_etcd_service_ip = "${var.k8s_etcd_service_ip}"
+    k8s_dns_service_ip   = "${module.bootkube.kube_dns_service_ip}"
+    k8s_etcd_service_ip  = "${module.bootkube.etcd_service_ip}"
     ssh_authorized_key  = "${var.ssh_authorized_key}"
   }
 }

--- a/examples/terraform/modules/bootkube/variables.tf
+++ b/examples/terraform/modules/bootkube/variables.tf
@@ -69,33 +69,12 @@ variable "pod_cidr" {
 }
 
 variable "service_cidr" {
-  description = "CIDR IP range to assign Kubernetes services"
+  description = <<EOD
+CIDR IP range to assign Kubernetes services.
+The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for kube-dns, the 15th IP will be reserved for self-hosted etcd, and the 200th IP will be reserved for bootstrap self-hosted etcd.
+EOD
   type        = "string"
   default     = "10.3.0.0/16"
-}
-
-variable "k8s_apiserver_service_ip" {
-  description = "Kubernetes service IP for kube-apiserver (must be within service_cidr)"
-  type        = "string"
-  default     = "10.3.0.1"
-}
-
-variable "k8s_dns_service_ip" {
-  description = "Kubernetes service IP for kube-dns (must be within server_cidr)"
-  type        = "string"
-  default     = "10.3.0.10"
-}
-
-variable "k8s_etcd_service_ip" {
-  type        = "string"
-  default     = "10.3.0.15"
-  description = "Kubernetes service IP for self-hosted etcd, if enabled (must be within service_cidr)"
-}
-
-variable "k8s_bootstrap_etcd_service_ip" {
-  type        = "string"
-  default     = "10.3.0.200"
-  description = "Kubernetes service IP for bootstrap self-hosted etcd, if enabled (must be within service_cidr)"
 }
 
 variable "container_linux_oem" {


### PR DESCRIPTION
Use the Terraform `cidrhost` interpolation, based on the same trick in use in https://github.com/coreos/tectonic-installer/pull/767.

This removes the ability to input the service IP's, but these were not truly customizable anyway. `bootkube start` (bootstrapping) has assumptions about the offset for each service component (kube-apiserver, kube-dns, self-hosted etcd, bootstrap self-hosted etcd). The correct values will be calculated on the user's behalf.