### PR TITLE
Update Kubernetes from v1.6.2 to v1.6.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ Notable changes between releases.
 
 ### Examples
 
-* Upgrade self-hosted Kubernetes cluster examples to v1.6.2
+* Upgrade self-hosted Kubernetes cluster examples to v1.6.4
 * Add NoSchedule taint to self-hosted Kubernetes controllers
 
 ## v0.6.0 (2017-04-25)

--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes
 
-The self-hosted Kubernetes example provisions a 3 node "self-hosted" Kubernetes v1.6.2 cluster. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run once on a controller node to bootstrap Kubernetes control plane components as pods before exiting. An etcd3 cluster across controllers is used to back Kubernetes and coordinate Container Linux auto-updates (enabled for disk installs).
+The self-hosted Kubernetes example provisions a 3 node "self-hosted" Kubernetes v1.6.4 cluster. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run once on a controller node to bootstrap Kubernetes control plane components as pods before exiting. An etcd3 cluster across controllers is used to back Kubernetes and coordinate Container Linux auto-updates (enabled for disk installs).
 
 ## Requirements
 
@@ -11,11 +11,11 @@ Ensure that you've gone through the [matchbox with rkt](getting-started-rkt.md) 
 * Create the example libvirt client VMs
 * `/etc/hosts` entries for `node[1-3].example.com` (or pass custom names to `k8s-certgen`)
 
-Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.4.3 and add it somewhere on your PATH.
+Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.4.4 and add it somewhere on your PATH.
 
 ```sh
 $ bootkube version
-Version: v0.4.3
+Version: v0.4.4
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ Create [example](examples) clusters on-premise or locally with [QEMU/KVM](script
 
 * [simple-install](Documentation/getting-started.md) - Install Container Linux with an SSH key on all machines (beginner)
 * [etcd3](examples/terraform/etcd3-install/README.md) - Install a 3-node etcd3 cluster
-* [Kubernetes](examples/terraform/bootkube-install/README.md) - Install a 3-node self-hosted Kubernetes v1.6.2 cluster
+* [Kubernetes](examples/terraform/bootkube-install/README.md) - Install a 3-node self-hosted Kubernetes v1.6.4 cluster
 * Terraform [Modules](examples/terraform/modules) - Re-usable Terraform Modules
 
 **Manual**
 
 * [etcd3](Documentation/getting-started-rkt.md) - Install a 3-node etcd3 cluster
-* [Kubernetes](Documentation/bootkube.md) - Install a 3-node self-hosted Kubernetes v1.6.2 cluster
+* [Kubernetes](Documentation/bootkube.md) - Install a 3-node self-hosted Kubernetes v1.6.4 cluster
 * Static [Kubernetes](Documentation/kubernetes.md) (discouraged, static systemd units)
 * Static [rktnetes](Documentation/rktnetes.md) (discouraged, static systemd units)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ These examples use [Terraform](https://www.terraform.io/intro/) as a client to M
 |-------------------------------|-------------------------------|
 | [simple-install](terraform/simple-install) | Install Container Linux with an SSH key |
 | [etcd3-install](terraform/etcd3-install) | Install a 3-node etcd3 cluster |
-| [bootkube-install](terraform/bootkube-install) | Install a 3-node self-hosted Kubernetes v1.6.2 cluster |
+| [bootkube-install](terraform/bootkube-install) | Install a 3-node self-hosted Kubernetes v1.6.4 cluster |
 
 ### Customization
 

--- a/examples/ignition/bootkube-controller.yaml
+++ b/examples/ignition/bootkube-controller.yaml
@@ -118,7 +118,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-          KUBELET_IMAGE_TAG=v1.6.2_coreos.0
+          KUBELET_IMAGE_TAG=v1.6.4_coreos.0
     - path: /etc/hostname
       filesystem: root
       mode: 0644
@@ -143,7 +143,7 @@ storage:
           # Wrapper for bootkube start
           set -e
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.4.3}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.4.4}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/opt/bootkube/assets}"
           exec /usr/bin/rkt run \
             --trust-keys-from-https \

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -107,7 +107,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-          KUBELET_IMAGE_TAG=v1.6.2_coreos.0
+          KUBELET_IMAGE_TAG=v1.6.4_coreos.0
     - path: /etc/hostname
       filesystem: root
       mode: 0644

--- a/examples/terraform/bootkube-install/README.md
+++ b/examples/terraform/bootkube-install/README.md
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes
 
-The self-hosted Kubernetes example shows how to use matchbox to network boot and provision a 3 node "self-hosted" Kubernetes v1.6.2 cluster. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run once on a controller node to bootstrap Kubernetes control plane components as pods before exiting.
+The self-hosted Kubernetes example shows how to use matchbox to network boot and provision a 3 node "self-hosted" Kubernetes v1.6.4 cluster. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run once on a controller node to bootstrap Kubernetes control plane components as pods before exiting.
 
 ## Requirements
 

--- a/examples/terraform/modules/bootkube/bootkube.tf
+++ b/examples/terraform/modules/bootkube/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/dghubble/bootkube-terraform.git?ref=368f09bcf189e1fe9d6185e1795e3c4bf8b1fab4"
+  source = "git::https://github.com/dghubble/bootkube-terraform.git?ref=3720aff28a465987e079dcd74fe3b6d5046d7010"
 
   cluster_name                  = "${var.cluster_name}"
   api_servers                   = ["${var.k8s_domain_name}"]

--- a/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
@@ -126,7 +126,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-          KUBELET_IMAGE_TAG=v1.6.2_coreos.0
+          KUBELET_IMAGE_TAG=v1.6.4_coreos.0
     - path: /etc/hostname
       filesystem: root
       mode: 0644
@@ -154,7 +154,7 @@ storage:
           [ -d /opt/bootkube/assets/experimental/manifests ] && mv /opt/bootkube/assets/experimental/manifests/* /opt/bootkube/assets/manifests && rm -r /opt/bootkube/assets/experimental/manifests
           [ -d /opt/bootkube/assets/experimental/bootstrap-manifests ] && mv /opt/bootkube/assets/experimental/bootstrap-manifests/* /opt/bootkube/assets/bootstrap-manifests && rm -r /opt/bootkube/assets/experimental/bootstrap-manifests
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.4.3}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.4.4}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/opt/bootkube/assets}"
           exec /usr/bin/rkt run \
             --trust-keys-from-https \

--- a/examples/terraform/modules/profiles/cl/bootkube-worker.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/bootkube-worker.yaml.tmpl
@@ -112,7 +112,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-          KUBELET_IMAGE_TAG=v1.6.2_coreos.0
+          KUBELET_IMAGE_TAG=v1.6.4_coreos.0
     - path: /etc/hostname
       filesystem: root
       mode: 0644

--- a/scripts/get-bootkube
+++ b/scripts/get-bootkube
@@ -4,7 +4,7 @@
 set -eu
 
 DEST=${1:-"bin"}
-VERSION="v0.4.3"
+VERSION="v0.4.4"
 
 URL="https://github.com/kubernetes-incubator/bootkube/releases/download/${VERSION}/bootkube.tar.gz"
 

--- a/tests/smoke/bootkube-terraform
+++ b/tests/smoke/bootkube-terraform
@@ -71,8 +71,11 @@ cleanup() {
   if [[ -z "$TERRAFORM_PID" ]]; then
     kill $TERRAFORM_PID
   fi
-  rm -rf examples/terraform/bootkube-install/assets
-  rm -f examples/terraform/bootkube-install/*.tfstate*
+  pushd examples/terraform/bootkube-install
+  echo "yes" | terraform destroy || true
+  rm -f *.tfstate*
+  rm -rf assets
+  popd
 }
 
 main $@

--- a/tests/smoke/etcd3-terraform
+++ b/tests/smoke/etcd3-terraform
@@ -39,7 +39,10 @@ cleanup() {
   ./scripts/libvirt destroy || true
   ./scripts/devnet destroy || true
   rkt gc --grace-period=0
-  rm -f examples/terraform/etcd3-install/*.tfstate*
+  pushd examples/terraform/etcd3-install
+  echo "yes" | terraform destroy || true
+  rm -f *.tfstate*
+  popd
 }
 
 main $@


### PR DESCRIPTION
* Update bootkube example cluster to v1.6.4
* Update bootkube (terraform-based) cluster to v1.6.4
* Update bootkube Terraform module to v1.6.4
* Uses bootkube v0.4.4 https://github.com/kubernetes-incubator/bootkube/releases/tag/v0.4.4

cc @aaronlevy @diegs 