### PR TITLE
Update CoreOS to the latest available version

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -39,8 +39,8 @@ GET http://matchbox.foo/ipxe?label=value
 
 ```
 #!ipxe
-kernel /assets/coreos/1298.7.0/coreos_production_pxe.vmlinuz coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp} coreos.first_boot=1 coreos.autologin
-initrd  /assets/coreos/1298.7.0/coreos_production_pxe_image.cpio.gz
+kernel /assets/coreos/1353.7.0/coreos_production_pxe.vmlinuz coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp} coreos.first_boot=1 coreos.autologin
+initrd  /assets/coreos/1353.7.0/coreos_production_pxe_image.cpio.gz
 boot
 ```
 
@@ -67,9 +67,9 @@ default=0
 timeout=1
 menuentry "CoreOS" {
 echo "Loading kernel"
-linuxefi "(http;matchbox.foo:8080)/assets/coreos/1298.7.0/coreos_production_pxe.vmlinuz" "coreos.autologin" "coreos.config.url=http://matchbox.foo:8080/ignition" "coreos.first_boot"
+linuxefi "(http;matchbox.foo:8080)/assets/coreos/1353.7.0/coreos_production_pxe.vmlinuz" "coreos.autologin" "coreos.config.url=http://matchbox.foo:8080/ignition" "coreos.first_boot"
 echo "Loading initrd"
-initrdefi "(http;matchbox.foo:8080)/assets/coreos/1298.7.0/coreos_production_pxe_image.cpio.gz"
+initrdefi "(http;matchbox.foo:8080)/assets/coreos/1353.7.0/coreos_production_pxe_image.cpio.gz"
 }
 ```
 
@@ -231,7 +231,7 @@ If you need to serve static assets (e.g. kernel, initrd), `matchbox` can serve a
 ```
 matchbox.foo/assets/
 └── coreos
-    └── 1298.7.0
+    └── 1353.7.0
         ├── coreos_production_pxe.vmlinuz
         └── coreos_production_pxe_image.cpio.gz
     └── 1153.0.0

--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -30,7 +30,7 @@ The [examples](../examples) statically assign IP addresses to libvirt client VMs
 Download the CoreOS image assets referenced in the target [profile](../examples/profiles).
 
 ```sh
-$ ./scripts/get-coreos stable 1298.7.0 ./examples/assets
+$ ./scripts/get-coreos stable 1353.7.0 ./examples/assets
 ```
 
 Add your SSH public key to each machine group definition [as shown](../examples/README.md#ssh-keys).

--- a/Documentation/deployment.md
+++ b/Documentation/deployment.md
@@ -203,7 +203,7 @@ Certificate chain
 Download a recent CoreOS [release](https://coreos.com/releases/) with signatures.
 
 ```sh
-$ ./scripts/get-coreos stable 1298.7.0 .     # note the "." 3rd argument
+$ ./scripts/get-coreos stable 1353.7.0 .     # note the "." 3rd argument
 ```
 
 Move the images to `/var/lib/matchbox/assets`,
@@ -215,7 +215,7 @@ $ sudo cp -r coreos /var/lib/matchbox/assets
 ```
 /var/lib/matchbox/assets/
 ├── coreos
-│   └── 1298.7.0
+│   └── 1353.7.0
 │       ├── CoreOS_Image_Signing_Key.asc
 │       ├── coreos_production_image.bin.bz2
 │       ├── coreos_production_image.bin.bz2.sig
@@ -228,7 +228,7 @@ $ sudo cp -r coreos /var/lib/matchbox/assets
 and verify the images are acessible.
 
 ```sh
-$ curl http://matchbox.example.com:8080/assets/coreos/1298.7.0/
+$ curl http://matchbox.example.com:8080/assets/coreos/1353.7.0/
 <pre>...
 ```
 

--- a/Documentation/getting-started-docker.md
+++ b/Documentation/getting-started-docker.md
@@ -29,7 +29,7 @@ $ cd matchbox
 Download CoreOS image assets referenced by the `etcd-docker` [example](../examples) to `examples/assets`.
 
 ```sh
-$ ./scripts/get-coreos stable 1298.7.0 ./examples/assets
+$ ./scripts/get-coreos stable 1353.7.0 ./examples/assets
 ```
 
 For development convenience, add `/etc/hosts` entries for nodes so they may be referenced by name as you would in production.

--- a/Documentation/getting-started-rkt.md
+++ b/Documentation/getting-started-rkt.md
@@ -30,7 +30,7 @@ $ cd matchbox
 Download CoreOS image assets referenced by the `etcd` [example](../examples) to `examples/assets`.
 
 ```sh
-$ ./scripts/get-coreos stable 1298.7.0 ./examples/assets
+$ ./scripts/get-coreos stable 1353.7.0 ./examples/assets
 ```
 
 ## Network

--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -24,7 +24,7 @@ The [examples](../examples) statically assign IP addresses to libvirt client VMs
 Download the CoreOS image assets referenced in the target [profile](../examples/profiles).
 
 ```sh
-$ ./scripts/get-coreos stable 1298.7.0 ./examples/assets
+$ ./scripts/get-coreos stable 1353.7.0 ./examples/assets
 ```
 
 Optionally, add your SSH public key to each machine group definition [as shown](../examples/README.md#ssh-keys).

--- a/Documentation/matchbox.md
+++ b/Documentation/matchbox.md
@@ -64,8 +64,8 @@ Profiles reference an Ignition config, Cloud-Config, and/or generic config by na
   "ignition_id": "etcd.yaml",
   "generic_id": "some-service.cfg",
   "boot": {
-    "kernel": "/assets/coreos/1298.7.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1298.7.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1353.7.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1353.7.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",

--- a/Documentation/rktnetes.md
+++ b/Documentation/rktnetes.md
@@ -24,7 +24,7 @@ The [examples](../examples) statically assign IP addresses to libvirt client VMs
 Download the CoreOS image assets referenced in the target [profile](../examples/profiles).
 
 ```sh
-$ ./scripts/get-coreos stable 1298.7.0 ./examples/assets
+$ ./scripts/get-coreos stable 1353.7.0 ./examples/assets
 ```
 
 Optionally, add your SSH public key to each machine group definition [as shown](../examples/README.md#ssh-keys).

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,17 +22,17 @@ These examples mount raw Matchbox objects into a Matchbox server's `/var/lib/mat
 
 | Name       | Description | CoreOS Version | FS | Docs | 
 |------------|-------------|----------------|----|-----------|
-| simple | CoreOS with autologin, using iPXE | stable/1298.7.0 | RAM | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
-| simple-install | CoreOS Install, using iPXE | stable/1298.7.0 | RAM | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
-| grub | CoreOS via GRUB2 Netboot | stable/1298.7.0 | RAM | NA |
-| etcd3 | A 3 node etcd3 cluster with proxies | stable/1298.7.0 | RAM | None |
-| etcd3-install | Install a 3 node etcd3 cluster to disk | stable/1298.7.0 | Disk | None |
-| k8s | Kubernetes cluster with 1 master, 2 workers, and TLS-authentication | stable/1298.7.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
-| k8s-install | Kubernetes cluster, installed to disk | stable/1298.7.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
-| rktnetes | Kubernetes cluster with rkt container runtime, 1 master, workers, TLS auth (experimental) | stable/1298.7.0 | Disk | [tutorial](../Documentation/rktnetes.md) |
-| rktnetes-install | Kubernetes cluster with rkt container runtime, installed to disk (experimental) | stable/1298.7.0 | Disk | [tutorial](../Documentation/rktnetes.md) |
-| bootkube | iPXE boot a self-hosted Kubernetes cluster (with bootkube) | stable/1298.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
-| bootkube-install | Install a self-hosted Kubernetes cluster (with bootkube) | stable/1298.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
+| simple | CoreOS with autologin, using iPXE | stable/1353.7.0 | RAM | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
+| simple-install | CoreOS Install, using iPXE | stable/1353.7.0 | RAM | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
+| grub | CoreOS via GRUB2 Netboot | stable/1353.7.0 | RAM | NA |
+| etcd3 | A 3 node etcd3 cluster with proxies | stable/1353.7.0 | RAM | None |
+| etcd3-install | Install a 3 node etcd3 cluster to disk | stable/1353.7.0 | Disk | None |
+| k8s | Kubernetes cluster with 1 master, 2 workers, and TLS-authentication | stable/1353.7.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
+| k8s-install | Kubernetes cluster, installed to disk | stable/1353.7.0 | Disk | [tutorial](../Documentation/kubernetes.md) |
+| rktnetes | Kubernetes cluster with rkt container runtime, 1 master, workers, TLS auth (experimental) | stable/1353.7.0 | Disk | [tutorial](../Documentation/rktnetes.md) |
+| rktnetes-install | Kubernetes cluster with rkt container runtime, installed to disk (experimental) | stable/1353.7.0 | Disk | [tutorial](../Documentation/rktnetes.md) |
+| bootkube | iPXE boot a self-hosted Kubernetes cluster (with bootkube) | stable/1353.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
+| bootkube-install | Install a self-hosted Kubernetes cluster (with bootkube) | stable/1353.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
 
 ### Customization
 

--- a/examples/groups/bootkube-install/install.json
+++ b/examples/groups/bootkube-install/install.json
@@ -4,7 +4,7 @@
   "profile": "install-reboot",
   "metadata": {
     "coreos_channel": "stable",
-    "coreos_version": "1298.7.0",
+    "coreos_version": "1353.7.0",
     "ignition_endpoint": "http://matchbox.foo:8080/ignition",
     "baseurl": "http://matchbox.foo:8080/assets/coreos"
   }

--- a/examples/groups/etcd3-install/install.json
+++ b/examples/groups/etcd3-install/install.json
@@ -4,7 +4,7 @@
   "profile": "install-reboot",
   "metadata": {
     "coreos_channel": "stable",
-    "coreos_version": "1298.7.0",
+    "coreos_version": "1353.7.0",
     "ignition_endpoint": "http://matchbox.foo:8080/ignition",
     "baseurl": "http://matchbox.foo:8080/assets/coreos"
   }

--- a/examples/groups/k8s-install/install.json
+++ b/examples/groups/k8s-install/install.json
@@ -4,7 +4,7 @@
   "profile": "install-reboot",
   "metadata": {
     "coreos_channel": "stable",
-    "coreos_version": "1298.7.0",
+    "coreos_version": "1353.7.0",
     "ignition_endpoint": "http://matchbox.foo:8080/ignition",
     "baseurl": "http://matchbox.foo:8080/assets/coreos"
   }

--- a/examples/groups/rktnetes-install/install.json
+++ b/examples/groups/rktnetes-install/install.json
@@ -4,7 +4,7 @@
   "profile": "install-reboot",
   "metadata": {
     "coreos_channel": "stable",
-    "coreos_version": "1298.7.0",
+    "coreos_version": "1353.7.0",
     "ignition_endpoint": "http://matchbox.foo:8080/ignition",
     "baseurl": "http://matchbox.foo:8080/assets/coreos"
   }

--- a/examples/groups/simple-install/install.json
+++ b/examples/groups/simple-install/install.json
@@ -4,7 +4,7 @@
   "profile": "simple-install",
   "metadata": {
     "coreos_channel": "stable",
-    "coreos_version": "1298.7.0",
+    "coreos_version": "1353.7.0",
     "ignition_endpoint": "http://matchbox.foo:8080/ignition",
     "baseurl": "http://matchbox.foo:8080/assets/coreos"
   }

--- a/examples/profiles/bootkube-controller.json
+++ b/examples/profiles/bootkube-controller.json
@@ -2,8 +2,8 @@
   "id": "bootkube-controller",
   "name": "bootkube Ready Controller",
   "boot": {
-    "kernel": "/assets/coreos/1298.7.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1298.7.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1353.7.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1353.7.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "root=/dev/sda1",
       "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",

--- a/examples/profiles/bootkube-worker.json
+++ b/examples/profiles/bootkube-worker.json
@@ -2,8 +2,8 @@
   "id": "bootkube-worker",
   "name": "bootkube Ready Worker",
   "boot": {
-    "kernel": "/assets/coreos/1298.7.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1298.7.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1353.7.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1353.7.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "root=/dev/sda1",
       "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",

--- a/examples/profiles/etcd3-gateway.json
+++ b/examples/profiles/etcd3-gateway.json
@@ -2,8 +2,8 @@
   "id": "etcd3-gateway",
   "name": "etcd3-gateway",
   "boot": {
-    "kernel": "/assets/coreos/1298.7.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1298.7.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1353.7.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1353.7.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",

--- a/examples/profiles/etcd3.json
+++ b/examples/profiles/etcd3.json
@@ -2,8 +2,8 @@
   "id": "etcd3",
   "name": "etcd3",
   "boot": {
-    "kernel": "/assets/coreos/1298.7.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1298.7.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1353.7.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1353.7.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",

--- a/examples/profiles/grub.json
+++ b/examples/profiles/grub.json
@@ -2,8 +2,8 @@
   "id": "grub",
   "name": "CoreOS via GRUB2",
   "boot": {
-    "kernel": "(http;matchbox.foo:8080)/assets/coreos/1298.7.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["(http;matchbox.foo:8080)/assets/coreos/1298.7.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "(http;matchbox.foo:8080)/assets/coreos/1353.7.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["(http;matchbox.foo:8080)/assets/coreos/1353.7.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "coreos.config.url=http://matchbox.foo:8080/ignition",
       "coreos.first_boot=yes",

--- a/examples/profiles/install-reboot.json
+++ b/examples/profiles/install-reboot.json
@@ -2,8 +2,8 @@
   "id": "install-reboot",
   "name": "Install CoreOS and Reboot",
   "boot": {
-    "kernel": "/assets/coreos/1298.7.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1298.7.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1353.7.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1353.7.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",

--- a/examples/profiles/install-shutdown.json
+++ b/examples/profiles/install-shutdown.json
@@ -2,8 +2,8 @@
   "id": "install-shutdown",
   "name": "Install CoreOS and Shutdown",
   "boot": {
-    "kernel": "/assets/coreos/1298.7.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1298.7.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1353.7.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1353.7.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",

--- a/examples/profiles/k8s-controller.json
+++ b/examples/profiles/k8s-controller.json
@@ -2,8 +2,8 @@
   "id": "k8s-controller",
   "name": "Kubernetes Controller",
   "boot": {
-    "kernel": "/assets/coreos/1298.7.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1298.7.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1353.7.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1353.7.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "root=/dev/sda1",
       "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",

--- a/examples/profiles/k8s-worker.json
+++ b/examples/profiles/k8s-worker.json
@@ -2,8 +2,8 @@
   "id": "k8s-worker",
   "name": "Kubernetes Worker",
   "boot": {
-    "kernel": "/assets/coreos/1298.7.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1298.7.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1353.7.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1353.7.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "root=/dev/sda1",
       "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",

--- a/examples/profiles/simple-install.json
+++ b/examples/profiles/simple-install.json
@@ -2,8 +2,8 @@
   "id": "simple-install",
   "name": "Simple CoreOS Alpha Install",
   "boot": {
-    "kernel": "/assets/coreos/1298.7.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1298.7.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1353.7.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1353.7.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",

--- a/examples/profiles/simple.json
+++ b/examples/profiles/simple.json
@@ -2,8 +2,8 @@
 	"id": "simple",
 	"name": "Simple CoreOS Alpha",
 	"boot": {
-		"kernel": "/assets/coreos/1298.7.0/coreos_production_pxe.vmlinuz",
-		"initrd": ["/assets/coreos/1298.7.0/coreos_production_pxe_image.cpio.gz"],
+		"kernel": "/assets/coreos/1353.7.0/coreos_production_pxe.vmlinuz",
+		"initrd": ["/assets/coreos/1353.7.0/coreos_production_pxe_image.cpio.gz"],
 		"args": [
 			"coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
 			"coreos.first_boot=yes",

--- a/examples/terraform/bootkube-install/README.md
+++ b/examples/terraform/bootkube-install/README.md
@@ -34,7 +34,7 @@ matchbox_http_endpoint = "http://matchbox.example.com:8080"
 matchbox_rpc_endpoint = "matchbox.example.com:8081"
 
 cluster_name = "demo"
-container_linux_version = "1298.7.0"
+container_linux_version = "1353.7.0"
 container_linux_channel = "stable"
 ssh_authorized_key = "ADD ME"
 ```

--- a/examples/terraform/bootkube-install/terraform.tfvars.example
+++ b/examples/terraform/bootkube-install/terraform.tfvars.example
@@ -3,7 +3,7 @@ matchbox_rpc_endpoint = "matchbox.example.com:8081"
 # ssh_authorized_key = "ADD ME"
 
 cluster_name = "example"
-container_linux_version = "1298.7.0"
+container_linux_version = "1353.7.0"
 container_linux_channel = "stable"
 
 # Machines

--- a/examples/terraform/etcd3-install/etcd3.tf
+++ b/examples/terraform/etcd3-install/etcd3.tf
@@ -2,7 +2,7 @@
 module "profiles" {
   source                  = "../modules/profiles"
   matchbox_http_endpoint  = "${var.matchbox_http_endpoint}"
-  container_linux_version = "1298.7.0"
+  container_linux_version = "1353.7.0"
   container_linux_channel = "stable"
 }
 
@@ -14,7 +14,7 @@ resource "matchbox_group" "default" {
   // No selector, matches all nodes
   metadata {
     container_linux_channel = "stable"
-    container_linux_version = "1298.7.0"
+    container_linux_version = "1353.7.0"
     container_linux_oem     = "${var.container_linux_oem}"
     ignition_endpoint       = "${var.matchbox_http_endpoint}/ignition"
     baseurl                 = "${var.matchbox_http_endpoint}/assets/coreos"

--- a/scripts/devnet
+++ b/scripts/devnet
@@ -10,7 +10,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 EXAMPLE=${2:-}
 BRIDGE=metal0
 COREOS_CHANNEL=stable
-COREOS_VERSION=1298.7.0
+COREOS_VERSION=1353.7.0
 MATCHBOX_ARGS=""
 
 ASSETS_DIR="${ASSETS_DIR:-$PWD/examples/assets}"

--- a/scripts/get-coreos
+++ b/scripts/get-coreos
@@ -9,7 +9,7 @@ set -eou pipefail
 GPG=${GPG:-/usr/bin/gpg}
 
 CHANNEL=${1:-"stable"}
-VERSION=${2:-"1298.7.0"}
+VERSION=${2:-"1353.7.0"}
 DEST_DIR=${3:-"$PWD/examples/assets"}
 OEM_ID=${OEM_ID:-""}
 DEST=$DEST_DIR/coreos/$VERSION

--- a/tests/smoke/bootkube.tfvars
+++ b/tests/smoke/bootkube.tfvars
@@ -3,7 +3,7 @@ matchbox_rpc_endpoint = "matchbox.example.com:8081"
 ssh_authorized_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDPQFdwVLr+alsWIgYRz9OdqDhnx9jjuFbkdSdpqq4gd9uZApYlivMDD4UgjFazQpezx8DiNhu9ym7i6LgAcdwi+10hE4L9yoJv9uBgbBxOAd65znqLqF91NtV4mlKP5YfJtR7Ehs+pTB+IIC+o5veDbPn+BYgDMJ2x7Osbn1/gFSDken/yoOFbYbRMGMfVEQYjJzC4r/qCKH0bl/xuVNLxf9FkWSTCcQFKGOndwuGITDkshD4r2Kk8gUddXPxoahBv33/2QH0CY5zbKYjhgN6I6WtwO+O1uJwtNeV1AGhYjurdd60qggNwx+W7623uK3nIXvJd3hzDO8u5oa53/tIL fake-test-key"
 
 cluster_name = "example"
-container_linux_version = "1298.7.0"
+container_linux_version = "1353.7.0"
 container_linux_channel = "stable"
 
 # Machines


### PR DESCRIPTION
Based on [CoreOS Release Page](https://coreos.com/releases/), the latest stable version is `1353.7.0`.

#### Reason to update

A newly created cluster randomly updated a few machines to `1353.7.0` and left some on the current version.

#### Updated components

| component | cur. version | upd. version |
| --- | --- | --- |
| kernel | 4.9.16 | 4.9.24 |
| rkt | 1.21.0 | [1.25.0](https://github.com/rkt/rkt/blob/master/CHANGELOG.md#1250) |
| systemd | 231 | [233](https://github.com/systemd/systemd/blob/master/NEWS) |

#### Known Issues

Testing so far has revealed no incompatibility or issues, compared to `1298.7.0`.