### PR TITLE
CHANGES.md: Prepare for a v0.6.1 docs point release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@ Notable changes between releases.
 
 * Remove pixiecore support (deprecated in v0.5.0)
 
+## v0.6.1 (2017-05-25)
+
+* Improve the installation documentation
+* Move examples/etc/matchbox/cert-gen to scripts/tls
+* Build Matchbox with Go 1.8.3 for images and binaries
+
 ### Examples
 
 * Upgrade self-hosted Kubernetes cluster examples to v1.6.4

--- a/Documentation/deployment.md
+++ b/Documentation/deployment.md
@@ -43,12 +43,14 @@ $ cd matchbox-v0.6.0-linux-amd64
 
 ### RPM-based distro
 
-On an RPM-based provisioner, install the `matchbox` RPM from the Copr [repository](https://copr.fedorainfracloud.org/coprs/g/CoreOS/matchbox/) using `dnf` or `yum`.
+On an RPM-based provisioner (Fedora 24+), install the `matchbox` RPM from the Copr [repository](https://copr.fedorainfracloud.org/coprs/g/CoreOS/matchbox/) using `dnf`.
 
 ```sh
 dnf copr enable @CoreOS/matchbox
 dnf install matchbox
 ```
+
+RPMs are not currently available for CentOS and RHEL (due to Go version). CentOS and RHEL users should follow the Generic Linux section below.
 
 ### CoreOS
 

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -34,7 +34,7 @@ Install [Terraform][terraform-dl] v0.9+ on your system.
 
 ```sh
 $ terraform version
-Terraform v0.9.2
+Terraform v0.9.4
 ```
 
 Add the `terraform-provider-matchbox` plugin binary on your system.

--- a/scripts/devnet
+++ b/scripts/devnet
@@ -91,7 +91,7 @@ function create {
     --volume config,kind=host,source=$CONFIG_DIR,readOnly=true \
     --mount volume=data,target=/var/lib/matchbox \
     $DATA_MOUNT \
-    quay.io/coreos/matchbox:ed6dde528a0146fe55551a317cc55849cec6ec80 -- -address=0.0.0.0:8080 -log-level=debug $MATCHBOX_ARGS
+    quay.io/coreos/matchbox:23f23c1dcb78b123754ffb4e64f21cd8269093ce -- -address=0.0.0.0:8080 -log-level=debug $MATCHBOX_ARGS
 
   echo "Starting dnsmasq to provide DHCP/TFTP/DNS services"
   rkt rm --uuid-file=/var/run/dnsmasq-pod.uuid > /dev/null 2>&1


### PR DESCRIPTION
* Release will allow docs team to update docs (also closes https://github.com/coreos/tectonic-installer/issues/672)
* Release branch will be used to avoid deprecation changes being included in the point release
* Bumping Go to 1.8.3 for release images and binaries (#552)
* I'm not planning an RPM release. Docs and Go build version are independent from RPM releases so there are effectively no changes to the package.
* Clarifies #550 

Branch to be tagged:
https://github.com/coreos/matchbox/tree/release-v0.6.1