### PR TITLE
Update openpgp package and bump Go to 1.8.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 go:
   - 1.7.4
-  - 1.8
+  - 1.8.3
   - tip
 matrix:
   allow_failures:
@@ -19,6 +19,6 @@ deploy:
   skip_cleanup: true
   on:
     branch: master
-    go: '1.8'
+    go: '1.8.3'
 notifications:
   email: change

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 205de0b66ed059a1f10d3fb36c7d465439818123940a9aaa68ddc71cc3bbfddd
-updated: 2017-04-17T17:09:48.864562358-07:00
+hash: 7de5ab95677974311285feaa83e24f127bbb4c64a68740bab24d71f491e8b689
+updated: 2017-05-24T15:28:05.291154327-07:00
 imports:
 - name: github.com/ajeddeloh/go-json
   version: 73d058cf8437a1989030afe571eeab9f90eebbbd
@@ -80,7 +80,7 @@ imports:
   subpackages:
   - errorutil
 - name: golang.org/x/crypto
-  version: 5dc8cb4b8a8eb076cbb5a06bc3b8682c15bdbbd3
+  version: 7e9105388ebff089b3f99f0ef676ea55a6da3a7e
   subpackages:
   - cast5
   - openpgp

--- a/glide.yaml
+++ b/glide.yaml
@@ -59,7 +59,7 @@ import:
 - package: github.com/spf13/cobra
   version: 65a708cee0a4424f4e353d031ce440643e312f92
 - package: golang.org/x/crypto
-  version: 5dc8cb4b8a8eb076cbb5a06bc3b8682c15bdbbd3
+  version: 7e9105388ebff089b3f99f0ef676ea55a6da3a7e
   subpackages:
   - cast5
   - openpgp

--- a/vendor/golang.org/x/crypto/openpgp/keys.go
+++ b/vendor/golang.org/x/crypto/openpgp/keys.go
@@ -307,8 +307,6 @@ func readToNextPublicKey(packets *packet.Reader) (err error) {
 			return
 		}
 	}
-
-	panic("unreachable")
 }
 
 // ReadEntity reads an entity (public key, identities, subkeys etc) from the
@@ -502,6 +500,12 @@ func NewEntity(name, comment, email string, config *packet.Config) (*Entity, err
 			FlagCertify:  true,
 			IssuerKeyId:  &e.PrimaryKey.KeyId,
 		},
+	}
+
+	// If the user passes in a DefaultHash via packet.Config,
+	// set the PreferredHash for the SelfSignature.
+	if config != nil && config.DefaultHash != 0 {
+		e.Identities[uid.Id].SelfSignature.PreferredHash = []uint8{hashToHashId(config.DefaultHash)}
 	}
 
 	e.Subkeys = make([]Subkey, 1)

--- a/vendor/golang.org/x/crypto/openpgp/packet/packet.go
+++ b/vendor/golang.org/x/crypto/openpgp/packet/packet.go
@@ -273,8 +273,6 @@ func consumeAll(r io.Reader) (n int64, err error) {
 			return
 		}
 	}
-
-	panic("unreachable")
 }
 
 // packetType represents the numeric ids of the different OpenPGP packet types. See

--- a/vendor/golang.org/x/crypto/openpgp/packet/public_key_v3.go
+++ b/vendor/golang.org/x/crypto/openpgp/packet/public_key_v3.go
@@ -216,7 +216,6 @@ func (pk *PublicKeyV3) VerifySignatureV3(signed hash.Hash, sig *SignatureV3) (er
 		// V3 public keys only support RSA.
 		panic("shouldn't happen")
 	}
-	panic("unreachable")
 }
 
 // VerifyUserIdSignatureV3 returns nil iff sig is a valid signature, made by this

--- a/vendor/golang.org/x/crypto/openpgp/packet/signature.go
+++ b/vendor/golang.org/x/crypto/openpgp/packet/signature.go
@@ -8,10 +8,12 @@ import (
 	"bytes"
 	"crypto"
 	"crypto/dsa"
-	"crypto/rsa"
+	"crypto/ecdsa"
+	"encoding/asn1"
 	"encoding/binary"
 	"hash"
 	"io"
+	"math/big"
 	"strconv"
 	"time"
 
@@ -515,7 +517,8 @@ func (sig *Signature) Sign(h hash.Hash, priv *PrivateKey, config *Config) (err e
 
 	switch priv.PubKeyAlgo {
 	case PubKeyAlgoRSA, PubKeyAlgoRSASignOnly:
-		sig.RSASignature.bytes, err = rsa.SignPKCS1v15(config.Random(), priv.PrivateKey.(*rsa.PrivateKey), sig.Hash, digest)
+		// supports both *rsa.PrivateKey and crypto.Signer
+		sig.RSASignature.bytes, err = priv.PrivateKey.(crypto.Signer).Sign(config.Random(), digest, sig.Hash)
 		sig.RSASignature.bitLength = uint16(8 * len(sig.RSASignature.bytes))
 	case PubKeyAlgoDSA:
 		dsaPriv := priv.PrivateKey.(*dsa.PrivateKey)
@@ -532,11 +535,40 @@ func (sig *Signature) Sign(h hash.Hash, priv *PrivateKey, config *Config) (err e
 			sig.DSASigS.bytes = s.Bytes()
 			sig.DSASigS.bitLength = uint16(8 * len(sig.DSASigS.bytes))
 		}
+	case PubKeyAlgoECDSA:
+		var r, s *big.Int
+		if pk, ok := priv.PrivateKey.(*ecdsa.PrivateKey); ok {
+			// direct support, avoid asn1 wrapping/unwrapping
+			r, s, err = ecdsa.Sign(config.Random(), pk, digest)
+		} else {
+			var b []byte
+			b, err = priv.PrivateKey.(crypto.Signer).Sign(config.Random(), digest, nil)
+			if err == nil {
+				r, s, err = unwrapECDSASig(b)
+			}
+		}
+		if err == nil {
+			sig.ECDSASigR = fromBig(r)
+			sig.ECDSASigS = fromBig(s)
+		}
 	default:
 		err = errors.UnsupportedError("public key algorithm: " + strconv.Itoa(int(sig.PubKeyAlgo)))
 	}
 
 	return
+}
+
+// unwrapECDSASig parses the two integer components of an ASN.1-encoded ECDSA
+// signature.
+func unwrapECDSASig(b []byte) (r, s *big.Int, err error) {
+	var ecsdaSig struct {
+		R, S *big.Int
+	}
+	_, err = asn1.Unmarshal(b, &ecsdaSig)
+	if err != nil {
+		return
+	}
+	return ecsdaSig.R, ecsdaSig.S, nil
 }
 
 // SignUserId computes a signature from priv, asserting that pub is a valid
@@ -546,7 +578,7 @@ func (sig *Signature) Sign(h hash.Hash, priv *PrivateKey, config *Config) (err e
 func (sig *Signature) SignUserId(id string, pub *PublicKey, priv *PrivateKey, config *Config) error {
 	h, err := userIdSignatureHash(id, pub, sig.Hash)
 	if err != nil {
-		return nil
+		return err
 	}
 	return sig.Sign(h, priv, config)
 }

--- a/vendor/golang.org/x/crypto/openpgp/s2k/s2k.go
+++ b/vendor/golang.org/x/crypto/openpgp/s2k/s2k.go
@@ -251,7 +251,7 @@ func HashIdToHash(id byte) (h crypto.Hash, ok bool) {
 }
 
 // HashIdToString returns the name of the hash function corresponding to the
-// given OpenPGP hash id, or panics if id is unknown.
+// given OpenPGP hash id.
 func HashIdToString(id byte) (name string, ok bool) {
 	for _, m := range hashToHashIdMapping {
 		if m.id == id {

--- a/vendor/golang.org/x/crypto/openpgp/write.go
+++ b/vendor/golang.org/x/crypto/openpgp/write.go
@@ -231,7 +231,7 @@ func Encrypt(ciphertext io.Writer, to []*Entity, signed *Entity, hints *FileHint
 	}
 
 	cipher := packet.CipherFunction(candidateCiphers[0])
-	// If the cipher specifed by config is a candidate, we'll use that.
+	// If the cipher specified by config is a candidate, we'll use that.
 	configuredCipher := config.Cipher()
 	for _, c := range candidateCiphers {
 		cipherFunc := packet.CipherFunction(c)


### PR DESCRIPTION
Shouldn't really affect us, but let's bump to the new Go version and update vendored openpgp since it hasn't been updated in a while and uses `elliptic.P256()`



