### PR TITLE
Add some minor Terraform variables

### DIFF
--- a/examples/terraform/bootkube-install/README.md
+++ b/examples/terraform/bootkube-install/README.md
@@ -32,16 +32,16 @@ Copy the `terraform.tfvars.example` file to `terraform.tfvars`. Ensure `provider
 ```hcl
 matchbox_http_endpoint = "http://matchbox.example.com:8080"
 matchbox_rpc_endpoint = "matchbox.example.com:8081"
+ssh_authorized_key = "ADD ME"
 
 cluster_name = "demo"
 container_linux_version = "1353.7.0"
 container_linux_channel = "stable"
-ssh_authorized_key = "ADD ME"
 ```
 
 Provide an ordered list of controller names, MAC addresses, and domain names. Provide an ordered list of worker names, MAC addresses, and domain names.
 
-```
+```hcl
 controller_names = ["node1"]
 controller_macs = ["52:54:00:a1:9c:ae"]
 controller_domains = ["node1.example.com"]
@@ -50,18 +50,26 @@ worker_macs = ["52:54:00:b2:2f:86", "52:54:00:c3:61:77"]
 worker_domains = ["node2.example.com", "node3.example.com"]
 ```
 
-Finally, provide an `assets_dir` for generated manifests and a DNS name which you've setup to resolves to controller(s) (e.g. round-robin). Worker nodes and your kubeconfig will communicate via this endpoint.
+Provide an `assets_dir` for generated manifests and a DNS name which you've setup to resolves to controller(s) (e.g. round-robin). Worker nodes and your kubeconfig will communicate via this endpoint.
 
-```
+```hcl
 k8s_domain_name = "cluster.example.com"
 asset_dir = "assets"
 ```
 
-### Options
+Note: The `cached-container-linux-install` profile will PXE boot and install Container Linux from matchbox [assets](https://github.com/coreos/matchbox/blob/master/Documentation/api.md#assets). If you have not populated the assets cache, use the `container-linux-install` profile to use public images (slower).
 
-You may set `experimental_self_hosted_etcd = "true"` to deploy "self-hosted" etcd atop Kubernetes instead of running etcd on hosts directly. Warning, this is experimental and potentially dangerous.
+### Optional
 
-The example above defines a Kubernetes cluster with 1 controller and 2 workers. Check the `multi-controller.tfvars.example` for an example which defines 3 controllers and one worker.
+You may set certain optional variables to override defaults. Set `experimental_self_hosted_etcd = "true"` to deploy "self-hosted" etcd atop Kubernetes instead of running etcd on hosts directly.
+
+```hcl
+# install_disk = "/dev/sda"
+# container_linux_oem = ""
+# experimental_self_hosted_etcd = "true"
+```
+
+The default is to create a Kubernetes cluster with 1 controller and 2 workers as an example, but check `multi-controller.tfvars.example` for an example which defines 3 controllers and 1 worker.
 
 ## Apply
 
@@ -94,8 +102,6 @@ Apply complete! Resources: 37 added, 0 changed, 0 destroyed.
 ```
 
 You can now move on to the "Machines" section. Apply will loop until it can successfully copy the kubeconfig to each node and start the one-time Kubernetes bootstrapping process on a controller. In practice, you may see `apply` fail if it connects before the disk install has completed. Run terraform apply until it reconciles successfully.
-
-Note: The `cached-container-linux-install` profile will PXE boot and install Container Linux from matchbox [assets](https://github.com/coreos/matchbox/blob/master/Documentation/api.md#assets). If you have not populated the assets cache, use the `container-linux-install` profile to use public images (slower).
 
 ## Machines
 

--- a/examples/terraform/bootkube-install/cluster.tf
+++ b/examples/terraform/bootkube-install/cluster.tf
@@ -22,6 +22,7 @@ module "cluster" {
   asset_dir       = "${var.asset_dir}"
 
   # Optional
+  cached_install                = "${var.cached_install}"
   install_disk                  = "${var.install_disk}"
   container_linux_oem           = "${var.container_linux_oem}"
   experimental_self_hosted_etcd = "${var.experimental_self_hosted_etcd}"

--- a/examples/terraform/bootkube-install/cluster.tf
+++ b/examples/terraform/bootkube-install/cluster.tf
@@ -18,10 +18,11 @@ module "cluster" {
   worker_domains     = "${var.worker_domains}"
 
   # bootkube assets
-  k8s_domain_name               = "${var.k8s_domain_name}"
-  asset_dir                     = "${var.asset_dir}"
+  k8s_domain_name = "${var.k8s_domain_name}"
+  asset_dir       = "${var.asset_dir}"
 
   # Optional
+  install_disk                  = "${var.install_disk}"
   container_linux_oem           = "${var.container_linux_oem}"
   experimental_self_hosted_etcd = "${var.experimental_self_hosted_etcd}"
 }

--- a/examples/terraform/bootkube-install/terraform.tfvars.example
+++ b/examples/terraform/bootkube-install/terraform.tfvars.example
@@ -18,7 +18,8 @@ worker_domains = ["node2.example.com", "node3.example.com"]
 k8s_domain_name = "cluster.example.com"
 asset_dir = "assets"
 
-# Optional
+# Optional (defaults)
+cached_install = "true"
 # install_disk = "/dev/sda"
 # container_linux_oem = ""
-# experimental_self_hosted_etcd = "true"
+# experimental_self_hosted_etcd = "false"

--- a/examples/terraform/bootkube-install/terraform.tfvars.example
+++ b/examples/terraform/bootkube-install/terraform.tfvars.example
@@ -19,5 +19,6 @@ k8s_domain_name = "cluster.example.com"
 asset_dir = "assets"
 
 # Optional
+# install_disk = "/dev/sda"
 # container_linux_oem = ""
 # experimental_self_hosted_etcd = "true"

--- a/examples/terraform/bootkube-install/variables.tf
+++ b/examples/terraform/bootkube-install/variables.tf
@@ -85,6 +85,12 @@ EOD
 
 # optional
 
+variable "cached_install" {
+  type        = "string"
+  default     = "false"
+  description = "Whether Container Linux should PXE boot and install from matchbox /assets cache. Note that the admin must have downloaded the container_linux_version into matchbox assets."
+}
+
 variable "install_disk" {
   type        = "string"
   default     = "/dev/sda"

--- a/examples/terraform/bootkube-install/variables.tf
+++ b/examples/terraform/bootkube-install/variables.tf
@@ -78,8 +78,17 @@ variable "service_cidr" {
 CIDR IP range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for kube-dns, the 15th IP will be reserved for self-hosted etcd, and the 200th IP will be reserved for bootstrap self-hosted etcd.
 EOD
+
+  type    = "string"
+  default = "10.3.0.0/16"
+}
+
+# optional
+
+variable "install_disk" {
   type        = "string"
-  default     = "10.3.0.0/16"
+  default     = "/dev/sda"
+  description = "Disk device to which the install profiles should install Container Linux (e.g. /dev/sda)"
 }
 
 variable "container_linux_oem" {

--- a/examples/terraform/etcd3-install/README.md
+++ b/examples/terraform/etcd3-install/README.md
@@ -37,6 +37,19 @@ ssh_authorized_key = "ADD ME"
 
 Configs in `etcd3-install` configure the matchbox provider, define profiles (e.g. `cached-container-linux-install`, `etcd3`), and define 3 groups which match machines by MAC address to a profile. These resources declare that the machines should PXE boot, install Container Linux to disk, and provision themselves into peers in a 3-node etcd3 cluster.
 
+Note: The `cached-container-linux-install` profile will PXE boot and install Container Linux from matchbox [assets](https://github.com/coreos/matchbox/blob/master/Documentation/api.md#assets). If you have not populated the assets cache, use the `container-linux-install` profile to use public images (slower).
+
+### Optional
+
+You may set certain optional variables to override defaults.
+
+```hcl
+# install_disk = "/dev/sda"
+# container_linux_oem = ""
+```
+
+## Apply
+
 Fetch the [profiles](../README.md#modules) Terraform [module](https://www.terraform.io/docs/modules/index.html) which let's you use common machine profiles maintained in the matchbox repo (like `etcd3`).
 
 ```sh
@@ -51,8 +64,6 @@ Plan: 10 to add, 0 to change, 0 to destroy.
 $ terraform apply
 Apply complete! Resources: 10 added, 0 changed, 0 destroyed.
 ```
-
-Note: The `cached-container-linux-install` profile will PXE boot and install Container Linux from matchbox [assets](https://github.com/coreos/matchbox/blob/master/Documentation/api.md#assets). If you have not populated the assets cache, use the `container-linux-install` profile to use public images (slower).
 
 ## Machines
 

--- a/examples/terraform/etcd3-install/etcd3.tf
+++ b/examples/terraform/etcd3-install/etcd3.tf
@@ -4,7 +4,8 @@ module "profiles" {
   matchbox_http_endpoint  = "${var.matchbox_http_endpoint}"
   container_linux_version = "1353.7.0"
   container_linux_channel = "stable"
-  install_disk = "${var.install_disk}"
+  install_disk            = "${var.install_disk}"
+  container_linux_oem     = "${var.container_linux_oem}"
 }
 
 // Install Container Linux to disk before provisioning
@@ -13,10 +14,9 @@ resource "matchbox_group" "default" {
   profile = "${module.profiles.cached-container-linux-install}"
 
   // No selector, matches all nodes
+
   metadata {
-    baseurl                 = "${var.matchbox_http_endpoint}/assets/coreos"
-    ssh_authorized_key      = "${var.ssh_authorized_key}"
-    container_linux_oem     = "${var.container_linux_oem}"
+    ssh_authorized_key = "${var.ssh_authorized_key}"
   }
 }
 

--- a/examples/terraform/etcd3-install/etcd3.tf
+++ b/examples/terraform/etcd3-install/etcd3.tf
@@ -13,12 +13,9 @@ resource "matchbox_group" "default" {
 
   // No selector, matches all nodes
   metadata {
-    container_linux_channel = "stable"
-    container_linux_version = "1353.7.0"
-    container_linux_oem     = "${var.container_linux_oem}"
-    ignition_endpoint       = "${var.matchbox_http_endpoint}/ignition"
     baseurl                 = "${var.matchbox_http_endpoint}/assets/coreos"
     ssh_authorized_key      = "${var.ssh_authorized_key}"
+    container_linux_oem     = "${var.container_linux_oem}"
   }
 }
 

--- a/examples/terraform/etcd3-install/etcd3.tf
+++ b/examples/terraform/etcd3-install/etcd3.tf
@@ -4,6 +4,7 @@ module "profiles" {
   matchbox_http_endpoint  = "${var.matchbox_http_endpoint}"
   container_linux_version = "1353.7.0"
   container_linux_channel = "stable"
+  install_disk = "${var.install_disk}"
 }
 
 // Install Container Linux to disk before provisioning

--- a/examples/terraform/etcd3-install/terraform.tfvars.example
+++ b/examples/terraform/etcd3-install/terraform.tfvars.example
@@ -3,4 +3,5 @@ matchbox_rpc_endpoint = "matchbox.example.com:8081"
 # ssh_authorized_key = "ADD ME"
 
 # Optional
+# install_disk = "/dev/sda"
 # container_linux_oem = ""

--- a/examples/terraform/etcd3-install/terraform.tfvars.example
+++ b/examples/terraform/etcd3-install/terraform.tfvars.example
@@ -2,6 +2,6 @@ matchbox_http_endpoint = "http://matchbox.example.com:8080"
 matchbox_rpc_endpoint = "matchbox.example.com:8081"
 # ssh_authorized_key = "ADD ME"
 
-# Optional
+# Optional (defaults)
 # install_disk = "/dev/sda"
 # container_linux_oem = ""

--- a/examples/terraform/etcd3-install/variables.tf
+++ b/examples/terraform/etcd3-install/variables.tf
@@ -13,14 +13,16 @@ variable "ssh_authorized_key" {
   description = "SSH public key to set as an authorized_key on machines"
 }
 
+# optional
+
 variable "install_disk" {
-  type = "string"
-  default = "/dev/sda"
+  type        = "string"
+  default     = "/dev/sda"
   description = "Disk device to which the install profiles should install Container Linux (e.g. /dev/sda)"
 }
 
 variable "container_linux_oem" {
-  type = "string"
-  default = ""
+  type        = "string"
+  default     = ""
   description = "Specify an OEM image id to use as base for the installation (e.g. ami, vmware_raw, xen) or leave blank for the default image"
 }

--- a/examples/terraform/etcd3-install/variables.tf
+++ b/examples/terraform/etcd3-install/variables.tf
@@ -13,6 +13,12 @@ variable "ssh_authorized_key" {
   description = "SSH public key to set as an authorized_key on machines"
 }
 
+variable "install_disk" {
+  type = "string"
+  default = "/dev/sda"
+  description = "Disk device to which the install profiles should install Container Linux (e.g. /dev/sda)"
+}
+
 variable "container_linux_oem" {
   type = "string"
   default = ""

--- a/examples/terraform/modules/bootkube/groups.tf
+++ b/examples/terraform/modules/bootkube/groups.tf
@@ -10,12 +10,9 @@ resource "matchbox_group" "container-linux-install" {
   }
 
   metadata {
-    container_linux_channel = "${var.container_linux_channel}"
-    container_linux_version = "${var.container_linux_version}"
-    container_linux_oem     = "${var.container_linux_oem}"
-    ignition_endpoint       = "${var.matchbox_http_endpoint}/ignition"
     baseurl                 = "${var.matchbox_http_endpoint}/assets/coreos"
     ssh_authorized_key      = "${var.ssh_authorized_key}"
+    container_linux_oem     = "${var.container_linux_oem}"
   }
 }
 

--- a/examples/terraform/modules/bootkube/groups.tf
+++ b/examples/terraform/modules/bootkube/groups.tf
@@ -3,16 +3,14 @@ resource "matchbox_group" "container-linux-install" {
   count = "${length(var.controller_names) + length(var.worker_names)}"
 
   name    = "${format("container-linux-install-%s", element(concat(var.controller_names, var.worker_names), count.index))}"
-  profile = "${module.profiles.cached-container-linux-install}"
+  profile = "${var.cached_install == "true" ? module.profiles.cached-container-linux-install : module.profiles.container-linux-install}"
 
   selector {
     mac = "${element(concat(var.controller_macs, var.worker_macs), count.index)}"
   }
 
   metadata {
-    baseurl                 = "${var.matchbox_http_endpoint}/assets/coreos"
-    ssh_authorized_key      = "${var.ssh_authorized_key}"
-    container_linux_oem     = "${var.container_linux_oem}"
+    ssh_authorized_key = "${var.ssh_authorized_key}"
   }
 }
 
@@ -51,8 +49,8 @@ resource "matchbox_group" "worker" {
     domain_name         = "${element(var.worker_domains, count.index)}"
     etcd_endpoints      = "${join(",", formatlist("%s:2379", var.controller_domains))}"
     etcd_on_host        = "${var.experimental_self_hosted_etcd ? "false" : "true"}"
-    k8s_dns_service_ip   = "${module.bootkube.kube_dns_service_ip}"
-    k8s_etcd_service_ip  = "${module.bootkube.etcd_service_ip}"
+    k8s_dns_service_ip  = "${module.bootkube.kube_dns_service_ip}"
+    k8s_etcd_service_ip = "${module.bootkube.etcd_service_ip}"
     ssh_authorized_key  = "${var.ssh_authorized_key}"
   }
 }

--- a/examples/terraform/modules/bootkube/profiles.tf
+++ b/examples/terraform/modules/bootkube/profiles.tf
@@ -4,5 +4,6 @@ module "profiles" {
   matchbox_http_endpoint  = "${var.matchbox_http_endpoint}"
   container_linux_version = "${var.container_linux_version}"
   container_linux_channel = "${var.container_linux_channel}"
-  install_disk = "${var.install_disk}"
+  install_disk            = "${var.install_disk}"
+  container_linux_oem     = "${var.container_linux_oem}"
 }

--- a/examples/terraform/modules/bootkube/profiles.tf
+++ b/examples/terraform/modules/bootkube/profiles.tf
@@ -4,4 +4,5 @@ module "profiles" {
   matchbox_http_endpoint  = "${var.matchbox_http_endpoint}"
   container_linux_version = "${var.container_linux_version}"
   container_linux_channel = "${var.container_linux_channel}"
+  install_disk = "${var.install_disk}"
 }

--- a/examples/terraform/modules/bootkube/variables.tf
+++ b/examples/terraform/modules/bootkube/variables.tf
@@ -73,15 +73,22 @@ variable "service_cidr" {
 CIDR IP range to assign Kubernetes services.
 The 1st IP will be reserved for kube_apiserver, the 10th IP will be reserved for kube-dns, the 15th IP will be reserved for self-hosted etcd, and the 200th IP will be reserved for bootstrap self-hosted etcd.
 EOD
-  type        = "string"
-  default     = "10.3.0.0/16"
+
+  type    = "string"
+  default = "10.3.0.0/16"
 }
 
 # optional
 
+variable "cached_install" {
+  type        = "string"
+  default     = "false"
+  description = "Whether Container Linux should PXE boot and install from matchbox /assets cache. Note that the admin must have downloaded the container_linux_version into matchbox assets."
+}
+
 variable "install_disk" {
-  type = "string"
-  default = "/dev/sda"
+  type        = "string"
+  default     = "/dev/sda"
   description = "Disk device to which the install profiles should install Container Linux (e.g. /dev/sda)"
 }
 

--- a/examples/terraform/modules/bootkube/variables.tf
+++ b/examples/terraform/modules/bootkube/variables.tf
@@ -77,6 +77,14 @@ EOD
   default     = "10.3.0.0/16"
 }
 
+# optional
+
+variable "install_disk" {
+  type = "string"
+  default = "/dev/sda"
+  description = "Disk device to which the install profiles should install Container Linux (e.g. /dev/sda)"
+}
+
 variable "container_linux_oem" {
   type        = "string"
   default     = ""

--- a/examples/terraform/modules/profiles/cl/container-linux-install.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/container-linux-install.yaml.tmpl
@@ -20,8 +20,8 @@ storage:
       contents:
         inline: |
           #!/bin/bash -ex
-          curl "{{.ignition_endpoint}}?{{.request.raw_query}}&os=installed" -o ignition.json
-          coreos-install -d /dev/sda -C {{.container_linux_channel}} -V {{.container_linux_version}} -i ignition.json {{if index . "baseurl"}}-b {{.baseurl}}{{end}} {{if index . "container_linux_oem"}}-o {{.container_linux_oem}}{{end}}
+          curl "${ignition_endpoint}?{{.request.raw_query}}&os=installed" -o ignition.json
+          coreos-install -d /dev/sda -C ${container_linux_channel} -V ${container_linux_version} -i ignition.json {{if index . "baseurl"}}-b {{.baseurl}}{{end}} {{if index . "container_linux_oem"}}-o {{.container_linux_oem}}{{end}}
           udevadm settle
           systemctl reboot
 passwd:

--- a/examples/terraform/modules/profiles/cl/container-linux-install.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/container-linux-install.yaml.tmpl
@@ -21,7 +21,13 @@ storage:
         inline: |
           #!/bin/bash -ex
           curl "${ignition_endpoint}?{{.request.raw_query}}&os=installed" -o ignition.json
-          coreos-install -d ${install_disk} -C ${container_linux_channel} -V ${container_linux_version} -i ignition.json {{if index . "baseurl"}}-b {{.baseurl}}{{end}} {{if index . "container_linux_oem"}}-o {{.container_linux_oem}}{{end}}
+          coreos-install \
+            -d ${install_disk} \
+            -C ${container_linux_channel} \
+            -V ${container_linux_version} \
+            -o "${container_linux_oem}" \
+            ${baseurl_flag} \
+            -i ignition.json
           udevadm settle
           systemctl reboot
 passwd:

--- a/examples/terraform/modules/profiles/cl/container-linux-install.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/container-linux-install.yaml.tmpl
@@ -21,7 +21,7 @@ storage:
         inline: |
           #!/bin/bash -ex
           curl "${ignition_endpoint}?{{.request.raw_query}}&os=installed" -o ignition.json
-          coreos-install -d /dev/sda -C ${container_linux_channel} -V ${container_linux_version} -i ignition.json {{if index . "baseurl"}}-b {{.baseurl}}{{end}} {{if index . "container_linux_oem"}}-o {{.container_linux_oem}}{{end}}
+          coreos-install -d ${install_disk} -C ${container_linux_channel} -V ${container_linux_version} -i ignition.json {{if index . "baseurl"}}-b {{.baseurl}}{{end}} {{if index . "container_linux_oem"}}-o {{.container_linux_oem}}{{end}}
           udevadm settle
           systemctl reboot
 passwd:

--- a/examples/terraform/modules/profiles/profiles.tf
+++ b/examples/terraform/modules/profiles/profiles.tf
@@ -17,6 +17,21 @@ resource "matchbox_profile" "container-linux-install" {
   container_linux_config = "${data.template_file.container-linux-install-config.rendered}"
 }
 
+data "template_file" "container-linux-install-config" {
+  template = "${file("${path.module}/cl/container-linux-install.yaml.tmpl")}"
+
+  vars {
+    container_linux_channel = "${var.container_linux_channel}"
+    container_linux_version = "${var.container_linux_version}"
+    ignition_endpoint       = "${format("%s/ignition", var.matchbox_http_endpoint)}"
+    install_disk            = "${var.install_disk}"
+    container_linux_oem     = "${var.container_linux_oem}"
+
+    # only cached-container-linux profile adds -b baseurl
+    baseurl_flag = ""
+  }
+}
+
 // Container Linux Install profile (from matchbox /assets cache)
 // Note: Admin must have downloaded container_linux_version into matchbox assets.
 resource "matchbox_profile" "cached-container-linux-install" {
@@ -34,17 +49,21 @@ resource "matchbox_profile" "cached-container-linux-install" {
     "console=ttyS0",
   ]
 
-  container_linux_config = "${data.template_file.container-linux-install-config.rendered}"
+  container_linux_config = "${data.template_file.cached-container-linux-install-config.rendered}"
 }
 
-data "template_file" "container-linux-install-config" {
+data "template_file" "cached-container-linux-install-config" {
   template = "${file("${path.module}/cl/container-linux-install.yaml.tmpl")}"
 
   vars {
     container_linux_channel = "${var.container_linux_channel}"
     container_linux_version = "${var.container_linux_version}"
-    ignition_endpoint = "${format("%s/ignition", var.matchbox_http_endpoint)}"
-    install_disk = "${var.install_disk}"
+    ignition_endpoint       = "${format("%s/ignition", var.matchbox_http_endpoint)}"
+    install_disk            = "${var.install_disk}"
+    container_linux_oem     = "${var.container_linux_oem}"
+
+    # profile uses -b baseurl to install from matchbox cache
+    baseurl_flag = "-b ${var.matchbox_http_endpoint}/assets/coreos"
   }
 }
 

--- a/examples/terraform/modules/profiles/profiles.tf
+++ b/examples/terraform/modules/profiles/profiles.tf
@@ -44,6 +44,7 @@ data "template_file" "container-linux-install-config" {
     container_linux_channel = "${var.container_linux_channel}"
     container_linux_version = "${var.container_linux_version}"
     ignition_endpoint = "${format("%s/ignition", var.matchbox_http_endpoint)}"
+    install_disk = "${var.install_disk}"
   }
 }
 

--- a/examples/terraform/modules/profiles/profiles.tf
+++ b/examples/terraform/modules/profiles/profiles.tf
@@ -14,7 +14,7 @@ resource "matchbox_profile" "container-linux-install" {
     "console=ttyS0",
   ]
 
-  container_linux_config = "${file("${path.module}/cl/container-linux-install.yaml.tmpl")}"
+  container_linux_config = "${data.template_file.container-linux-install-config.rendered}"
 }
 
 // Container Linux Install profile (from matchbox /assets cache)
@@ -34,7 +34,17 @@ resource "matchbox_profile" "cached-container-linux-install" {
     "console=ttyS0",
   ]
 
-  container_linux_config = "${file("${path.module}/cl/container-linux-install.yaml.tmpl")}"
+  container_linux_config = "${data.template_file.container-linux-install-config.rendered}"
+}
+
+data "template_file" "container-linux-install-config" {
+  template = "${file("${path.module}/cl/container-linux-install.yaml.tmpl")}"
+
+  vars {
+    container_linux_channel = "${var.container_linux_channel}"
+    container_linux_version = "${var.container_linux_version}"
+    ignition_endpoint = "${format("%s/ignition", var.matchbox_http_endpoint)}"
+  }
 }
 
 // etcd3 profile

--- a/examples/terraform/modules/profiles/variables.tf
+++ b/examples/terraform/modules/profiles/variables.tf
@@ -16,7 +16,13 @@ variable "container_linux_channel" {
 # optional
 
 variable "install_disk" {
-  type = "string"
-  default = "/dev/sda"
+  type        = "string"
+  default     = "/dev/sda"
   description = "Disk device to which the install profiles should install Container Linux (e.g. /dev/sda)"
+}
+
+variable "container_linux_oem" {
+  type        = "string"
+  default     = ""
+  description = "Specify an OEM image id to use as base for the installation (e.g. ami, vmware_raw, xen) or leave blank for the default image"
 }

--- a/examples/terraform/modules/profiles/variables.tf
+++ b/examples/terraform/modules/profiles/variables.tf
@@ -12,3 +12,11 @@ variable "container_linux_channel" {
   type        = "string"
   description = "Container Linux channel corresponding to the container_linux_version"
 }
+
+# optional
+
+variable "install_disk" {
+  type = "string"
+  default = "/dev/sda"
+  description = "Disk device to which the install profiles should install Container Linux (e.g. /dev/sda)"
+}

--- a/tests/smoke/bootkube.tfvars
+++ b/tests/smoke/bootkube.tfvars
@@ -19,5 +19,4 @@ k8s_domain_name = "cluster.example.com"
 asset_dir = "assets"
 
 # Optional
-# container_linux_oem = ""
-# experimental_self_hosted_etcd = "true"
+cached_install = "true"


### PR DESCRIPTION
Features in the re-usable modules:

- [x] Profiles `container-linux-install` and `cached-container-linux-install` allow the `install_disk` and `container_linux_oem` to be set
- [x] Update Container Linux config to use Terraform's variable substitution (early) rather than Matchbox template substitution (late, runtime) where possible. This should surface more errors before apply.
- [x] Terraform bootkube module allows toggling (`cached_install`) whether the cluster should PXE and install from the Matchbox cache of Container Linux images or from the public download site.

These same features need to make their way into Tectonic as well.

rel #545 #549 