### PR TITLE
Doc/deployment.md: Cp local config to correct location

### DIFF
--- a/Documentation/deployment.md
+++ b/Documentation/deployment.md
@@ -83,7 +83,7 @@ $ sudo chown -R matchbox:matchbox /var/lib/matchbox
 Copy the provided `matchbox` systemd unit file.
 
 ```sh
-$ sudo cp contrib/systemd/matchbox-local.service /etc/systemd/system/
+$ sudo cp contrib/systemd/matchbox-local.service /etc/systemd/system/matchbox.service
 ```
 
 ## Customization


### PR DESCRIPTION
Copy matchbox-local.service to /etc/systemd/system/matchbox.service
rather than bare dir.