### PR TITLE
examples: Use Kubernetes on-host etcd TLS

### DIFF
--- a/examples/groups/bootkube-install/node1.json
+++ b/examples/groups/bootkube-install/node1.json
@@ -8,7 +8,8 @@
   },
   "metadata": {
     "domain_name": "node1.example.com",
-    "etcd_initial_cluster": "node1=http://node1.example.com:2380",
+    "etcd_initial_cluster": "node1=https://node1.example.com:2380",
+    "etcd_endpoints": "https://node1.example.com:2379",
     "etcd_name": "node1",
     "k8s_dns_service_ip": "10.3.0.10",
     "ssh_authorized_keys": [

--- a/examples/groups/bootkube-install/node2.json
+++ b/examples/groups/bootkube-install/node2.json
@@ -8,7 +8,7 @@
   },
   "metadata": {
     "domain_name": "node2.example.com",
-    "etcd_endpoints": "node1.example.com:2379",
+    "etcd_endpoints": "https://node1.example.com:2379",
     "k8s_dns_service_ip": "10.3.0.10",
     "ssh_authorized_keys": [
       "ADD ME"

--- a/examples/groups/bootkube-install/node3.json
+++ b/examples/groups/bootkube-install/node3.json
@@ -8,7 +8,7 @@
   },
   "metadata": {
     "domain_name": "node3.example.com",
-    "etcd_endpoints": "node1.example.com:2379",
+    "etcd_endpoints": "https://node1.example.com:2379",
     "k8s_dns_service_ip": "10.3.0.10",
     "ssh_authorized_keys": [
       "ADD ME"

--- a/examples/groups/bootkube/node1.json
+++ b/examples/groups/bootkube/node1.json
@@ -7,7 +7,8 @@
   },
   "metadata": {
     "domain_name": "node1.example.com",
-    "etcd_initial_cluster": "node1=http://node1.example.com:2380",
+    "etcd_initial_cluster": "node1=https://node1.example.com:2380",
+    "etcd_endpoints": "https://node1.example.com:2379",
     "etcd_name": "node1",
     "k8s_dns_service_ip": "10.3.0.10",
     "pxe": "true",

--- a/examples/groups/bootkube/node2.json
+++ b/examples/groups/bootkube/node2.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "domain_name": "node2.example.com",
-    "etcd_endpoints": "node1.example.com:2379",
+    "etcd_endpoints": "https://node1.example.com:2379",
     "k8s_dns_service_ip": "10.3.0.10",
     "pxe": "true",
     "ssh_authorized_keys": [

--- a/examples/groups/bootkube/node3.json
+++ b/examples/groups/bootkube/node3.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "domain_name": "node3.example.com",
-    "etcd_endpoints": "node1.example.com:2379",
+    "etcd_endpoints": "https://node1.example.com:2379",
     "k8s_dns_service_ip": "10.3.0.10",
     "pxe": "true",
     "ssh_authorized_keys": [

--- a/examples/ignition/bootkube-controller.yaml
+++ b/examples/ignition/bootkube-controller.yaml
@@ -9,12 +9,19 @@ systemd:
             [Service]
             Environment="ETCD_IMAGE_TAG=v3.1.6"
             Environment="ETCD_NAME={{.etcd_name}}"
-            Environment="ETCD_ADVERTISE_CLIENT_URLS=http://{{.domain_name}}:2379"
-            Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=http://{{.domain_name}}:2380"
-            Environment="ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379"
-            Environment="ETCD_LISTEN_PEER_URLS=http://0.0.0.0:2380"
+            Environment="ETCD_ADVERTISE_CLIENT_URLS=https://{{.domain_name}}:2379"
+            Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=https://{{.domain_name}}:2380"
+            Environment="ETCD_LISTEN_CLIENT_URLS=https://0.0.0.0:2379"
+            Environment="ETCD_LISTEN_PEER_URLS=https://0.0.0.0:2380"
             Environment="ETCD_INITIAL_CLUSTER={{.etcd_initial_cluster}}"
             Environment="ETCD_STRICT_RECONFIG_CHECK=true"
+            Environment="ETCD_SSL_DIR=/etc/ssl/etcd"
+            Environment="ETCD_CERT_FILE=/etc/ssl/certs/etcd-client.crt"
+            Environment="ETCD_KEY_FILE=/etc/ssl/certs/etcd-client.key"
+            Environment="ETCD_PEER_CERT_FILE=/etc/ssl/certs/etcd-peer.crt"
+            Environment="ETCD_PEER_KEY_FILE=/etc/ssl/certs/etcd-peer.key"
+            Environment="ETCD_PEER_TRUSTED_CA_FILE=/etc/ssl/certs/etcd-ca.crt"
+            Environment="ETCD_PEER_CLIENT_CERT_AUTH=true"
     - name: docker.service
       enable: true
     - name: locksmithd.service
@@ -23,6 +30,10 @@ systemd:
           contents: |
             [Service]
             Environment="REBOOT_STRATEGY=etcd-lock"
+            Environment="LOCKSMITHD_ETCD_CAFILE=/etc/ssl/etcd/etcd-ca.crt"
+            Environment="LOCKSMITHD_ETCD_CERTFILE=/etc/ssl/etcd/etcd-client.crt"
+            Environment="LOCKSMITHD_ETCD_KEYFILE=/etc/ssl/etcd/etcd-client.key"
+            Environment="LOCKSMITHD_ENDPOINT={{.etcd_endpoints}}"
     - name: kubelet.path
       enable: true
       contents: |
@@ -119,6 +130,12 @@ storage:
         inline: |
           KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
           KUBELET_IMAGE_TAG=v1.6.4_coreos.0
+    - path: /etc/ssl/etcd/.empty
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          empty
     - path: /etc/hostname
       filesystem: root
       mode: 0644

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -1,17 +1,6 @@
 ---
 systemd:
   units:
-    - name: etcd-member.service
-      enable: true
-      dropins:
-        - name: 40-etcd-cluster.conf
-          contents: |
-            [Service]
-            Environment="ETCD_IMAGE_TAG=v3.1.6"
-            ExecStart=
-            ExecStart=/usr/lib/coreos/etcd-wrapper gateway start \
-              --listen-addr=127.0.0.1:2379 \
-              --endpoints={{.etcd_endpoints}}
     - name: docker.service
       enable: true
     - name: locksmithd.service
@@ -20,6 +9,10 @@ systemd:
           contents: |
             [Service]
             Environment="REBOOT_STRATEGY=etcd-lock"
+            Environment="LOCKSMITHD_ETCD_CAFILE=/etc/ssl/etcd/etcd-ca.crt"
+            Environment="LOCKSMITHD_ETCD_CERTFILE=/etc/ssl/etcd/etcd-client.crt"
+            Environment="LOCKSMITHD_ETCD_KEYFILE=/etc/ssl/etcd/etcd-client.key"
+            Environment="LOCKSMITHD_ENDPOINT={{.etcd_endpoints}}"
     - name: kubelet.path
       enable: true
       contents: |
@@ -108,6 +101,12 @@ storage:
         inline: |
           KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
           KUBELET_IMAGE_TAG=v1.6.4_coreos.0
+    - path: /etc/ssl/etcd/.empty
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          empty
     - path: /etc/hostname
       filesystem: root
       mode: 0644

--- a/examples/terraform/modules/bootkube/bootkube.tf
+++ b/examples/terraform/modules/bootkube/bootkube.tf
@@ -1,10 +1,10 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/dghubble/bootkube-terraform.git?ref=3720aff28a465987e079dcd74fe3b6d5046d7010"
+  source = "git::https://github.com/dghubble/bootkube-terraform.git?ref=21131aa65e371389fda72a93b86b59a84aa01c1b"
 
   cluster_name                  = "${var.cluster_name}"
   api_servers                   = ["${var.k8s_domain_name}"]
-  etcd_servers                  = ["http://127.0.0.1:2379"]
+  etcd_servers                  = ["${var.controller_domains}"]
   asset_dir                     = "${var.asset_dir}"
   pod_cidr                      = "${var.pod_cidr}"
   service_cidr                  = "${var.service_cidr}"

--- a/examples/terraform/modules/bootkube/groups.tf
+++ b/examples/terraform/modules/bootkube/groups.tf
@@ -27,7 +27,8 @@ resource "matchbox_group" "controller" {
   metadata {
     domain_name          = "${element(var.controller_domains, count.index)}"
     etcd_name            = "${element(var.controller_names, count.index)}"
-    etcd_initial_cluster = "${join(",", formatlist("%s=http://%s:2380", var.controller_names, var.controller_domains))}"
+    etcd_initial_cluster = "${join(",", formatlist("%s=https://%s:2380", var.controller_names, var.controller_domains))}"
+    etcd_endpoints      = "${join(",", formatlist("https://%s:2379", var.controller_domains))}"
     etcd_on_host         = "${var.experimental_self_hosted_etcd ? "false" : "true"}"
     k8s_dns_service_ip   = "${module.bootkube.kube_dns_service_ip}"
     k8s_etcd_service_ip  = "${module.bootkube.etcd_service_ip}"
@@ -47,7 +48,7 @@ resource "matchbox_group" "worker" {
 
   metadata {
     domain_name         = "${element(var.worker_domains, count.index)}"
-    etcd_endpoints      = "${join(",", formatlist("%s:2379", var.controller_domains))}"
+    etcd_endpoints      = "${join(",", formatlist("https://%s:2379", var.controller_domains))}"
     etcd_on_host        = "${var.experimental_self_hosted_etcd ? "false" : "true"}"
     k8s_dns_service_ip  = "${module.bootkube.kube_dns_service_ip}"
     k8s_etcd_service_ip = "${module.bootkube.etcd_service_ip}"

--- a/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
@@ -10,12 +10,19 @@ systemd:
             [Service]
             Environment="ETCD_IMAGE_TAG=v3.1.6"
             Environment="ETCD_NAME={{.etcd_name}}"
-            Environment="ETCD_ADVERTISE_CLIENT_URLS=http://{{.domain_name}}:2379"
-            Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=http://{{.domain_name}}:2380"
-            Environment="ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379"
-            Environment="ETCD_LISTEN_PEER_URLS=http://0.0.0.0:2380"
+            Environment="ETCD_ADVERTISE_CLIENT_URLS=https://{{.domain_name}}:2379"
+            Environment="ETCD_INITIAL_ADVERTISE_PEER_URLS=https://{{.domain_name}}:2380"
+            Environment="ETCD_LISTEN_CLIENT_URLS=https://0.0.0.0:2379"
+            Environment="ETCD_LISTEN_PEER_URLS=https://0.0.0.0:2380"
             Environment="ETCD_INITIAL_CLUSTER={{.etcd_initial_cluster}}"
             Environment="ETCD_STRICT_RECONFIG_CHECK=true"
+            Environment="ETCD_SSL_DIR=/etc/ssl/etcd"
+            Environment="ETCD_CERT_FILE=/etc/ssl/certs/etcd-client.crt"
+            Environment="ETCD_KEY_FILE=/etc/ssl/certs/etcd-client.key"
+            Environment="ETCD_PEER_CERT_FILE=/etc/ssl/certs/etcd-peer.crt"
+            Environment="ETCD_PEER_KEY_FILE=/etc/ssl/certs/etcd-peer.key"
+            Environment="ETCD_PEER_TRUSTED_CA_FILE=/etc/ssl/certs/etcd-ca.crt"
+            Environment="ETCD_PEER_CLIENT_CERT_AUTH=true"
     {{ end }}
     - name: docker.service
       enable: true
@@ -27,6 +34,11 @@ systemd:
             Environment="REBOOT_STRATEGY=etcd-lock"
             {{ if eq .etcd_on_host "false" -}}
             Environment="LOCKSMITHD_ENDPOINT=http://{{.k8s_etcd_service_ip}}:2379"
+            {{ else }}
+            Environment="LOCKSMITHD_ETCD_CAFILE=/etc/ssl/etcd/etcd-ca.crt"
+            Environment="LOCKSMITHD_ETCD_CERTFILE=/etc/ssl/etcd/etcd-client.crt"
+            Environment="LOCKSMITHD_ETCD_KEYFILE=/etc/ssl/etcd/etcd-client.key"
+            Environment="LOCKSMITHD_ENDPOINT={{.etcd_endpoints}}"
             {{ end }}
     - name: kubelet.path
       enable: true

--- a/examples/terraform/modules/profiles/cl/bootkube-worker.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/bootkube-worker.yaml.tmpl
@@ -1,19 +1,6 @@
 ---
 systemd:
   units:
-    {{ if eq .etcd_on_host "true" }}
-    - name: etcd-member.service
-      enable: true
-      dropins:
-        - name: 40-etcd-cluster.conf
-          contents: |
-            [Service]
-            Environment="ETCD_IMAGE_TAG=v3.1.6"
-            ExecStart=
-            ExecStart=/usr/lib/coreos/etcd-wrapper gateway start \
-              --listen-addr=127.0.0.1:2379 \
-              --endpoints={{.etcd_endpoints}}
-    {{ end }}
     - name: docker.service
       enable: true
     - name: locksmithd.service
@@ -24,6 +11,11 @@ systemd:
             Environment="REBOOT_STRATEGY=etcd-lock"
             {{ if eq .etcd_on_host "false" -}}
             Environment="LOCKSMITHD_ENDPOINT=http://{{.k8s_etcd_service_ip}}:2379"
+            {{ else }}
+            Environment="LOCKSMITHD_ETCD_CAFILE=/etc/ssl/etcd/etcd-ca.crt"
+            Environment="LOCKSMITHD_ETCD_CERTFILE=/etc/ssl/etcd/etcd-client.crt"
+            Environment="LOCKSMITHD_ETCD_KEYFILE=/etc/ssl/etcd/etcd-client.key"
+            Environment="LOCKSMITHD_ENDPOINT={{.etcd_endpoints}}"
             {{ end }}
     - name: kubelet.path
       enable: true

--- a/tests/smoke/bootkube
+++ b/tests/smoke/bootkube
@@ -15,12 +15,18 @@ main() {
   ./scripts/libvirt create
 
   echo "bootkube render"
-  ./bin/bootkube render --asset-dir=assets --api-servers=https://node1.example.com:443 --api-server-alt-names=DNS=node1.example.com --etcd-servers=http://127.0.0.1:2379
+  ./bin/bootkube render --asset-dir=assets --api-servers=https://node1.example.com:443 --api-server-alt-names=DNS=node1.example.com --etcd-servers=https://node1.example.com:2379
 
   for i in `seq 1 10`; do
     ssh node1.example.com -o ConnectTimeout=5 -- 'echo "Connected"' && break
     echo "Waiting for nodes to PXE boot..."
     sleep 10
+  done
+
+  echo "Add etcd certs to nodes"
+  for node in 'node1' 'node2' 'node3'; do
+    scp -r assets/tls/etcd-* core@$node.example.com:/home/core/
+    ssh core@$node.example.com 'sudo mkdir -p /etc/ssl/etcd && sudo mv etcd-* /etc/ssl/etcd/ && sudo chown -R etcd:etcd /etc/ssl/etcd && sudo chmod -R 500 /etc/ssl/etcd/'
   done
 
   echo "Add kubeconfig to nodes"


### PR DESCRIPTION
Matchbox Kubernetes cluster examples/modules now enable on-host etcd TLS always - there is not option to turn it off. Kubernetes clusters can now **finally!** be deployed in networks alongside untrusted servers. etcd TLS for experimental self-hosted etcd is tracked in #262.

* Require etcd3 cluster peers to use TLS to secure communication channels and require clients to be authenticated with a TLS client certificate
* kube-apiserver (including bootstrap) communicates with TLS authenticated on-host etcd cluster
* Configure locksmith to speak directly to an etcd nodes. Stop running an etcd gateway on workers.

Checked

* Tested (manual) bootkube example
* Tested (manual) bootkube-install example to ensure locksmithd coordinates auto-updates
* Tested (terraform) bootkube-install example



cc @diegs
Closes #565  