### PR TITLE
examples/terraform/modules: Add outputs.tf with kubeconfig

### DIFF
--- a/examples/terraform/modules/bootkube/outputs.tf
+++ b/examples/terraform/modules/bootkube/outputs.tf
@@ -1,0 +1,3 @@
+output "kubeconfig" {
+  value = "${module.bootkube.kubeconfig}"
+}


### PR DESCRIPTION
Enables module users to use the cluster's kubeconfig in their own, add-on infrastructure declarations, such as adding diskless workers.