### PR TITLE
Dockerfile: Update base image from alpine:3.5 to alpine:3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 MAINTAINER Dalton Hubble <dalton.hubble@coreos.com>
 COPY bin/matchbox /matchbox
 EXPOSE 8080


### PR DESCRIPTION
Clair scan picks up some zlib vulnerabilties. Not directly impacting, but alpine:3.6 has been out for a few weeks now.