### PR TITLE
contrib/k8s: Use two Ingress resources for HTTP and TLS gRPC

### DIFF
--- a/Documentation/deployment.md
+++ b/Documentation/deployment.md
@@ -302,7 +302,8 @@ Create an Ingress resource to expose the HTTP read-only and gRPC API endpoints. 
 $ kubectl create -f contrib/k8s/matchbox-ingress.yaml
 $ kubectl get ingress
 NAME      HOSTS                                          ADDRESS            PORTS     AGE
-matchbox  matchbox.example.com,matchbox-rpc.example.com  10.128.0.3,10...   80, 443   32m
+matchbox       matchbox.example.com                      10.128.0.3,10...   80        29m
+matchbox-rpc   matchbox-rpc.example.com                  10.128.0.3,10...   80, 443   29m
 ```
 
 Add DNS records `matchbox.example.com` and `matchbox-rpc.example.com` to route traffic to the Ingress Controller.

--- a/contrib/k8s/matchbox-ingress.yaml
+++ b/contrib/k8s/matchbox-ingress.yaml
@@ -2,12 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: matchbox
-  annotations:
-    ingress.kubernetes.io/ssl-passthrough: "true"
 spec:
-  tls:
-    - hosts:
-        - matchbox-rpc.example.com
   rules:
     - host: matchbox.example.com
       http:
@@ -16,6 +11,18 @@ spec:
             backend:
               serviceName: matchbox
               servicePort: 8080
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: matchbox
+  annotations:
+    ingress.kubernetes.io/ssl-passthrough: "true"
+spec:
+  tls:
+    - hosts:
+        - matchbox-rpc.example.com
+  rules:
     - host: matchbox-rpc.example.com
       http:
         paths:


### PR DESCRIPTION
* Fixes Ingress controller issue upgrading from nginx-ingress-controller 0.9-beta.3 to 0.9-beta.4 through 0.9-beta.7

Closes #575