### PR TITLE
Correct path to client.crt and client.key

### DIFF
--- a/Documentation/deployment.md
+++ b/Documentation/deployment.md
@@ -192,7 +192,7 @@ matchbox
 If you enabled the gRPC API,
 
 ```sh
-$ openssl s_client -connect matchbox.example.com:8081 -CAfile /etc/matchbox/ca.crt -cert examples/etc/matchbox/client.crt -key examples/etc/matchbox/client.key
+$ openssl s_client -connect matchbox.example.com:8081 -CAfile /etc/matchbox/ca.crt -cert scripts/tls/client.crt -key scripts/tls/client.key
 CONNECTED(00000003)
 depth=1 CN = fake-ca
 verify return:1


### PR DESCRIPTION
gRPC API verification step has invalid paths to client.crt and client.key; these are created in ~/matchbox-v0.6.1-linux-amd64/scripts/tls (depending on where the matchbox installer is extracted).