### PR TITLE
examples: Upgrade Kubernetes to v1.6.6

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Notable changes between releases.
 
 ### Examples / Modules
 
+* Upgrade Kubernetes v1.6.6 example clusters
 * Kubernetes examples clusters enable etcd TLS (unless experimental self-hosted etcd is enabled)
 
 ## v0.6.1 (2017-05-25)

--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes
 
-The self-hosted Kubernetes example provisions a 3 node "self-hosted" Kubernetes v1.6.4 cluster. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run once on a controller node to bootstrap Kubernetes control plane components as pods before exiting. An etcd3 cluster across controllers is used to back Kubernetes and coordinate Container Linux auto-updates (enabled for disk installs).
+The self-hosted Kubernetes example provisions a 3 node "self-hosted" Kubernetes v1.6.6 cluster. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run once on a controller node to bootstrap Kubernetes control plane components as pods before exiting. An etcd3 cluster across controllers is used to back Kubernetes and coordinate Container Linux auto-updates (enabled for disk installs).
 
 ## Requirements
 
@@ -11,11 +11,11 @@ Ensure that you've gone through the [matchbox with rkt](getting-started-rkt.md) 
 * Create the example libvirt client VMs
 * `/etc/hosts` entries for `node[1-3].example.com` (or pass custom names to `k8s-certgen`)
 
-Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.4.4 and add it somewhere on your PATH.
+Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.4.5 and add it on your $PATH.
 
 ```sh
 $ bootkube version
-Version: v0.4.4
+Version: v0.4.5
 ```
 
 ## Examples
@@ -78,7 +78,7 @@ for node in 'node1' 'node2' 'node3'; do
 done
 ```
 
-Secure copy the `bootkube` generated assets to any controller node and run `bootkube-start`.
+Secure copy the `bootkube` generated assets to any controller node and run `bootkube-start` (takes ~10 minutes).
 
 ```sh
 scp -r assets core@node1.example.com:/home/core
@@ -105,27 +105,27 @@ You may cleanup the `bootkube` assets on the node, but you should keep the copy 
 ```sh
 $ KUBECONFIG=assets/auth/kubeconfig
 $ kubectl get nodes
-NAME                STATUS    AGE
-node1.example.com   Ready     3m
-node2.example.com   Ready     3m
-node3.example.com   Ready     3m
+NAME                STATUS    AGE       VERSION
+node1.example.com   Ready     7m        v1.6.6+coreos.1
+node2.example.com   Ready     7m        v1.6.6+coreos.1
+node3.example.com   Ready     7m        v1.6.6+coreos.1
 
 $ kubectl get pods --all-namespaces
 NAMESPACE     NAME                                       READY     STATUS    RESTARTS   AGE
-kube-system   checkpoint-installer-p8g8r                 1/1       Running   1          13m
-kube-system   kube-apiserver-s5gnx                       1/1       Running   1          41s
-kube-system   kube-controller-manager-3438979800-jrlnd   1/1       Running   1          13m
-kube-system   kube-controller-manager-3438979800-tkjx7   1/1       Running   1          13m
-kube-system   kube-dns-4101612645-xt55f                  4/4       Running   4          13m
-kube-system   kube-flannel-pl5c2                         2/2       Running   0          13m
-kube-system   kube-flannel-r9t5r                         2/2       Running   3          13m
-kube-system   kube-flannel-vfb0s                         2/2       Running   4          13m
-kube-system   kube-proxy-cvhmj                           1/1       Running   0          13m
-kube-system   kube-proxy-hf9mh                           1/1       Running   1          13m
-kube-system   kube-proxy-kpl73                           1/1       Running   1          13m
-kube-system   kube-scheduler-694795526-1l23b             1/1       Running   1          13m
-kube-system   kube-scheduler-694795526-fks0b             1/1       Running   1          13m
-kube-system   pod-checkpointer-node1.example.com         1/1       Running   2          10m
+kube-system   kube-apiserver-zd1k3                       1/1       Running   0          7m
+kube-system   kube-controller-manager-762207937-2ztxb    1/1       Running   0          7m
+kube-system   kube-controller-manager-762207937-vf6bk    1/1       Running   1          7m
+kube-system   kube-dns-2431531914-qc752                  3/3       Running   0          7m
+kube-system   kube-flannel-180mz                         2/2       Running   1          7m
+kube-system   kube-flannel-jjr0x                         2/2       Running   0          7m
+kube-system   kube-flannel-mlr9w                         2/2       Running   0          7m
+kube-system   kube-proxy-0jlq7                           1/1       Running   0          7m
+kube-system   kube-proxy-k4mjl                           1/1       Running   0          7m
+kube-system   kube-proxy-l4xrd                           1/1       Running   0          7m
+kube-system   kube-scheduler-1873228005-5d2mk            1/1       Running   0          7m
+kube-system   kube-scheduler-1873228005-s4w27            1/1       Running   0          7m
+kube-system   pod-checkpointer-hb960                     1/1       Running   0          7m
+kube-system   pod-checkpointer-hb960-node1.example.com   1/1       Running   0          6m
 ```
 
 Try deleting pods to see that the cluster is resilient to failures and machine restarts (Container Linux auto-updates).

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ Create [example](examples) clusters on-premise or locally with [QEMU/KVM](script
 
 * [simple-install](Documentation/getting-started.md) - Install Container Linux with an SSH key on all machines (beginner)
 * [etcd3](examples/terraform/etcd3-install/README.md) - Install a 3-node etcd3 cluster
-* [Kubernetes](examples/terraform/bootkube-install/README.md) - Install a 3-node self-hosted Kubernetes v1.6.4 cluster
+* [Kubernetes](examples/terraform/bootkube-install/README.md) - Install a 3-node self-hosted Kubernetes v1.6.6 cluster
 * Terraform [Modules](examples/terraform/modules) - Re-usable Terraform Modules
 
 **Manual**
 
 * [etcd3](Documentation/getting-started-rkt.md) - Install a 3-node etcd3 cluster
-* [Kubernetes](Documentation/bootkube.md) - Install a 3-node self-hosted Kubernetes v1.6.4 cluster
+* [Kubernetes](Documentation/bootkube.md) - Install a 3-node self-hosted Kubernetes v1.6.6 cluster
 
 ## Contrib
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ These examples use [Terraform](https://www.terraform.io/intro/) as a client to M
 |-------------------------------|-------------------------------|
 | [simple-install](terraform/simple-install) | Install Container Linux with an SSH key |
 | [etcd3-install](terraform/etcd3-install) | Install a 3-node etcd3 cluster |
-| [bootkube-install](terraform/bootkube-install) | Install a 3-node self-hosted Kubernetes v1.6.4 cluster |
+| [bootkube-install](terraform/bootkube-install) | Install a 3-node self-hosted Kubernetes v1.6.6 cluster |
 
 ### Customization
 
@@ -27,8 +27,8 @@ These examples mount raw Matchbox objects into a Matchbox server's `/var/lib/mat
 | grub | CoreOS Container Linux via GRUB2 Netboot | stable/1353.7.0 | RAM | NA |
 | etcd3 | PXE boot a 3 node etcd3 cluster with proxies | stable/1353.7.0 | RAM | None |
 | etcd3-install | Install a 3 node etcd3 cluster to disk | stable/1353.7.0 | Disk | None |
-| bootkube | PXE boot a self-hosted Kubernetes v1.6.4 cluster | stable/1353.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
-| bootkube-install | Install a self-hosted Kubernetes v1.6.4 cluster | stable/1353.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
+| bootkube | PXE boot a self-hosted Kubernetes v1.6.6 cluster | stable/1353.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
+| bootkube-install | Install a self-hosted Kubernetes v1.6.6 cluster | stable/1353.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
 
 ### Customization
 

--- a/examples/ignition/bootkube-controller.yaml
+++ b/examples/ignition/bootkube-controller.yaml
@@ -129,7 +129,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-          KUBELET_IMAGE_TAG=v1.6.4_coreos.0
+          KUBELET_IMAGE_TAG=v1.6.6_coreos.1
     - path: /etc/ssl/etcd/.empty
       filesystem: root
       mode: 0644
@@ -160,7 +160,7 @@ storage:
           # Wrapper for bootkube start
           set -e
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.4.4}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.4.5}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/opt/bootkube/assets}"
           exec /usr/bin/rkt run \
             --trust-keys-from-https \

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -100,7 +100,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-          KUBELET_IMAGE_TAG=v1.6.4_coreos.0
+          KUBELET_IMAGE_TAG=v1.6.6_coreos.1
     - path: /etc/ssl/etcd/.empty
       filesystem: root
       mode: 0644

--- a/examples/terraform/bootkube-install/README.md
+++ b/examples/terraform/bootkube-install/README.md
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes
 
-The self-hosted Kubernetes example shows how to use matchbox to network boot and provision a 3 node "self-hosted" Kubernetes v1.6.4 cluster. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run once on a controller node to bootstrap Kubernetes control plane components as pods before exiting.
+The self-hosted Kubernetes example shows how to use matchbox to network boot and provision a 3 node "self-hosted" Kubernetes v1.6.6 cluster. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run once on a controller node to bootstrap Kubernetes control plane components as pods before exiting.
 
 ## Requirements
 

--- a/examples/terraform/modules/bootkube/bootkube.tf
+++ b/examples/terraform/modules/bootkube/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/dghubble/bootkube-terraform.git?ref=21131aa65e371389fda72a93b86b59a84aa01c1b"
+  source = "git::https://github.com/dghubble/bootkube-terraform.git?ref=v0.4.5"
 
   cluster_name                  = "${var.cluster_name}"
   api_servers                   = ["${var.k8s_domain_name}"]

--- a/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
@@ -138,7 +138,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-          KUBELET_IMAGE_TAG=v1.6.4_coreos.0
+          KUBELET_IMAGE_TAG=v1.6.6_coreos.1
     - path: /etc/hostname
       filesystem: root
       mode: 0644
@@ -166,7 +166,7 @@ storage:
           [ -d /opt/bootkube/assets/experimental/manifests ] && mv /opt/bootkube/assets/experimental/manifests/* /opt/bootkube/assets/manifests && rm -r /opt/bootkube/assets/experimental/manifests
           [ -d /opt/bootkube/assets/experimental/bootstrap-manifests ] && mv /opt/bootkube/assets/experimental/bootstrap-manifests/* /opt/bootkube/assets/bootstrap-manifests && rm -r /opt/bootkube/assets/experimental/bootstrap-manifests
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.4.4}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.4.5}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/opt/bootkube/assets}"
           exec /usr/bin/rkt run \
             --trust-keys-from-https \

--- a/examples/terraform/modules/profiles/cl/bootkube-worker.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/bootkube-worker.yaml.tmpl
@@ -104,7 +104,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-          KUBELET_IMAGE_TAG=v1.6.4_coreos.0
+          KUBELET_IMAGE_TAG=v1.6.6_coreos.1
     - path: /etc/hostname
       filesystem: root
       mode: 0644

--- a/scripts/dev/get-bootkube
+++ b/scripts/dev/get-bootkube
@@ -4,7 +4,7 @@
 set -eu
 
 DEST=${1:-"bin"}
-VERSION="v0.4.4"
+VERSION="v0.4.5"
 
 URL="https://github.com/kubernetes-incubator/bootkube/releases/download/${VERSION}/bootkube.tar.gz"
 

--- a/scripts/dev/get-kubectl
+++ b/scripts/dev/get-kubectl
@@ -4,7 +4,7 @@
 set -eu
 
 DEST=${1:-"bin"}
-VERSION="v1.6.4"
+VERSION="v1.6.6"
 
 URL="https://storage.googleapis.com/kubernetes-release/release/${VERSION}/bin/linux/amd64/kubectl"
 


### PR DESCRIPTION
* Upgrade to Kubernetes v1.6.6 and bootkube v0.4.5
* Enable TLS for experimental self-hosted etcd (on-host etcd TLS was added last time)
* Upstream manifest generation changes modify the flannel Daemonset, switch several control plane components to run as non-root, and add an explicit UpdateStrategy to the control plane components

Notes:

With this update, all Kubernetes clusters defined in the Matchbox project use etcd TLS.

Requires:

- [x] bootkube v0.4.5 image and tarball
- [x] bootkube Terraform module: https://github.com/coreos/bootkube-terraform/pull/1
- [x] Manual testing around experimental self-hosted etcd TLS pivoting