### PR TITLE
examples: Use etcd client certs in locksmithd dropin

### DIFF
--- a/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
@@ -32,12 +32,12 @@ systemd:
           contents: |
             [Service]
             Environment="REBOOT_STRATEGY=etcd-lock"
-            {{ if eq .etcd_on_host "false" -}}
-            Environment="LOCKSMITHD_ENDPOINT=http://{{.k8s_etcd_service_ip}}:2379"
-            {{ else }}
             Environment="LOCKSMITHD_ETCD_CAFILE=/etc/ssl/etcd/etcd-ca.crt"
             Environment="LOCKSMITHD_ETCD_CERTFILE=/etc/ssl/etcd/etcd-client.crt"
             Environment="LOCKSMITHD_ETCD_KEYFILE=/etc/ssl/etcd/etcd-client.key"
+            {{ if eq .etcd_on_host "false" -}}
+            Environment="LOCKSMITHD_ENDPOINT=http://{{.k8s_etcd_service_ip}}:2379"
+            {{ else }}
             Environment="LOCKSMITHD_ENDPOINT={{.etcd_endpoints}}"
             {{ end }}
     - name: kubelet.path

--- a/examples/terraform/modules/profiles/cl/bootkube-worker.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/bootkube-worker.yaml.tmpl
@@ -9,12 +9,12 @@ systemd:
           contents: |
             [Service]
             Environment="REBOOT_STRATEGY=etcd-lock"
-            {{ if eq .etcd_on_host "false" -}}
-            Environment="LOCKSMITHD_ENDPOINT=http://{{.k8s_etcd_service_ip}}:2379"
-            {{ else }}
             Environment="LOCKSMITHD_ETCD_CAFILE=/etc/ssl/etcd/etcd-ca.crt"
             Environment="LOCKSMITHD_ETCD_CERTFILE=/etc/ssl/etcd/etcd-client.crt"
             Environment="LOCKSMITHD_ETCD_KEYFILE=/etc/ssl/etcd/etcd-client.key"
+            {{ if eq .etcd_on_host "false" -}}
+            Environment="LOCKSMITHD_ENDPOINT=http://{{.k8s_etcd_service_ip}}:2379"
+            {{ else }}
             Environment="LOCKSMITHD_ENDPOINT={{.etcd_endpoints}}"
             {{ end }}
     - name: kubelet.path


### PR DESCRIPTION
* Fixes a regression introduced in 6f02107 which upgraded to Kubernetes v1.6.6 and added self-hosted etcd with TLS
* Both on-host and self-hosted etcd now require clients to use TLS client certs so locksmithd

Closes #590