### PR TITLE
scripts/devnet: open port 8081 when using docker

### DIFF
--- a/scripts/devnet
+++ b/scripts/devnet
@@ -170,6 +170,7 @@ function docker_create {
   docker run --name matchbox \
     -d \
     -p 8080:8080 \
+    -p 8081:8081 \
     -v $CONFIG_DIR:/etc/matchbox:Z \
     -v $ASSETS_DIR:/var/lib/matchbox/assets:Z \
     $DATA_MOUNT \


### PR DESCRIPTION
Otherwise the gRPC server is not accessible. 