### PR TITLE
examples: include 'curl' retries

### DIFF
--- a/examples/ignition/install-reboot.yaml
+++ b/examples/ignition/install-reboot.yaml
@@ -20,7 +20,7 @@ storage:
       contents:
         inline: |
           #!/bin/bash -ex
-          curl --fail "{{.ignition_endpoint}}?{{.request.raw_query}}&os=installed" -o ignition.json
+          curl --retry 10 --fail "{{.ignition_endpoint}}?{{.request.raw_query}}&os=installed" -o ignition.json
           coreos-install -d /dev/sda -C {{.coreos_channel}} -V {{.coreos_version}} -i ignition.json {{if index . "baseurl"}}-b {{.baseurl}}{{end}}
           udevadm settle
           systemctl reboot

--- a/examples/terraform/modules/profiles/cl/container-linux-install.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/container-linux-install.yaml.tmpl
@@ -20,7 +20,7 @@ storage:
       contents:
         inline: |
           #!/bin/bash -ex
-          curl "${ignition_endpoint}?{{.request.raw_query}}&os=installed" -o ignition.json
+          curl --retry 10 "${ignition_endpoint}?{{.request.raw_query}}&os=installed" -o ignition.json
           coreos-install \
             -d ${install_disk} \
             -C ${container_linux_channel} \

--- a/examples/terraform/simple-install/cl/coreos-install.yaml.tmpl
+++ b/examples/terraform/simple-install/cl/coreos-install.yaml.tmpl
@@ -20,7 +20,7 @@ storage:
       contents:
         inline: |
           #!/bin/bash -ex
-          curl "{{.ignition_endpoint}}?{{.request.raw_query}}&os=installed" -o ignition.json
+          curl --retry 10 "{{.ignition_endpoint}}?{{.request.raw_query}}&os=installed" -o ignition.json
           coreos-install -d /dev/sda -C stable -V current -i ignition.json {{if index . "baseurl"}}-b {{.baseurl}}{{end}}
           udevadm settle
           systemctl reboot


### PR DESCRIPTION
`After=network-online.target` *should* mean this isn't needed in most
cases, but per
https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/, the
definition of "network-online" is a little shaky.

Regardless, being a little more resilient to network flakes and races is
a good thing. The count of `10` was arbitrarily chosen.

No particular testing done.