### PR TITLE
Documentation tweaks

### DIFF
--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -124,7 +124,7 @@ resource "matchbox_profile" "coreos-install" {
 
 Matcher groups match machines based on labels like MAC, UUID, etc. to different profiles and templates in machine-specific values. This group does not have a `selector` block, so any machines which network boot from matchbox will match this group and be provisioned using the `coreos-install` profile. Machines are matched to the most specific matching group.
 
-```
+```hcl
 resource "matchbox_group" "default" {
   name = "default"
   profile = "${matchbox_profile.coreos-install.name}"

--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -122,7 +122,7 @@ resource "matchbox_profile" "coreos-install" {
 
 #### Groups
 
-Matcher groups match machines based on labels like MAC, UUID, etc. to different profiles and template in machine-specific values. This group does not have a `selector` block, so any machines which network boot from matchbox will match this group and be provisioned using the `coreos-install` profile. Machines are matched to the most specific matching group.
+Matcher groups match machines based on labels like MAC, UUID, etc. to different profiles and templates in machine-specific values. This group does not have a `selector` block, so any machines which network boot from matchbox will match this group and be provisioned using the `coreos-install` profile. Machines are matched to the most specific matching group.
 
 ```
 resource "matchbox_group" "default" {


### PR DESCRIPTION
I made a small fix to pluralize "templates" where it was previously written:

> [...] to different profiles and template in machine-specific values.

Additionally, I added syntax highlighting for the code example that follows.