### PR TITLE
Remove invalid port in grub.cfg example

### DIFF
--- a/Documentation/network-setup.md
+++ b/Documentation/network-setup.md
@@ -219,10 +219,17 @@ Grub can be used to delegate as well.
 
 /var/lib/tftpboot/boot/grub/grub.cfg:
 ```ini
-insmod i386-pc/http.mod
-set root=http,matchbox.foo:8080
+insmod http
+set root=http,matchbox.foo
 configfile /grub
 ```
+or, if you want to send the system's MAC address to matchbox for use in a profile selector:
+```ini
+insmod http
+set root=http,matchbox.foo
+configfile /grub?mac=$net_default_mac
+```
+*Note: Grub2's http module does not accept a port specification, so ensure that matchbox is running on port 80 instead of 8080 in this case*
 
 Make sure to replace variables in the example config files; instead of iPXE variables, use GRUB variables. Check the [GRUB2 manual](https://www.gnu.org/software/grub/manual/grub.html#Network).
 


### PR DESCRIPTION
docs: Remove invalid port in grub.cfg example

Grub2's http.mod doesn't allow for a port specification (assumes tcp/80), so it needs to be removed and a note about moving matchbox to listen on port 80.  Also, I added the $net_default_mac grub variable to be useful for profile selectors.