### PR TITLE
Update non-terraform Kubernetes to use bootkube v0.5.0

### DIFF
--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -11,11 +11,11 @@ Ensure that you've gone through the [matchbox with rkt](getting-started-rkt.md) 
 * Create the example libvirt client VMs
 * `/etc/hosts` entries for `node[1-3].example.com` (or pass custom names to `k8s-certgen`)
 
-Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.4.5 and add it on your $PATH.
+Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.5.0 and add it on your $PATH.
 
 ```sh
 $ bootkube version
-Version: v0.4.5
+Version: v0.5.0
 ```
 
 ## Examples
@@ -64,8 +64,8 @@ Secure copy the etcd TLS assets to `/etc/ssl/etcd/*` on **every** node.
 
 ```bash
 for node in 'node1' 'node2' 'node3'; do
-    scp -r assets/tls/etcd-* core@$node.example.com:/home/core/
-    ssh core@$node.example.com 'sudo mkdir -p /etc/ssl/etcd && sudo mv etcd-* /etc/ssl/etcd/ && sudo chown -R etcd:etcd /etc/ssl/etcd && sudo chmod -R 500 /etc/ssl/etcd/'
+    scp -r assets/tls/etcd-* assets/tls/etcd core@$node.example.com:/home/core/
+    ssh core@$node.example.com 'sudo mkdir -p /etc/ssl/etcd && sudo mv etcd-* etcd /etc/ssl/etcd/ && sudo chown -R etcd:etcd /etc/ssl/etcd && sudo chmod -R 500 /etc/ssl/etcd/'
 done
 ```
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
           },
           bootkube: {
             node('fedora && bare-metal') {
-              timeout(time:15, unit:'MINUTES') {
+              timeout(time:60, unit:'MINUTES') {
                 checkout scm          
                 sh '''#!/bin/bash -e
                 chmod 600 ./tests/smoke/fake_rsa
@@ -46,7 +46,7 @@ pipeline {
           },
           "bootkube-terraform": {
             node('fedora && bare-metal') {
-              timeout(time:15, unit:'MINUTES') {
+              timeout(time:60, unit:'MINUTES') {
                 checkout scm          
                 sh '''#!/bin/bash -e
                 chmod 600 ./tests/smoke/fake_rsa

--- a/examples/ignition/bootkube-controller.yaml
+++ b/examples/ignition/bootkube-controller.yaml
@@ -16,11 +16,13 @@ systemd:
             Environment="ETCD_INITIAL_CLUSTER={{.etcd_initial_cluster}}"
             Environment="ETCD_STRICT_RECONFIG_CHECK=true"
             Environment="ETCD_SSL_DIR=/etc/ssl/etcd"
-            Environment="ETCD_CERT_FILE=/etc/ssl/certs/etcd-client.crt"
-            Environment="ETCD_KEY_FILE=/etc/ssl/certs/etcd-client.key"
-            Environment="ETCD_PEER_CERT_FILE=/etc/ssl/certs/etcd-peer.crt"
-            Environment="ETCD_PEER_KEY_FILE=/etc/ssl/certs/etcd-peer.key"
-            Environment="ETCD_PEER_TRUSTED_CA_FILE=/etc/ssl/certs/etcd-ca.crt"
+            Environment="ETCD_TRUSTED_CA_FILE=/etc/ssl/certs/etcd/server-ca.crt"
+            Environment="ETCD_CERT_FILE=/etc/ssl/certs/etcd/server.crt"
+            Environment="ETCD_KEY_FILE=/etc/ssl/certs/etcd/server.key"
+            Environment="ETCD_CLIENT_CERT_AUTH=true"
+            Environment="ETCD_PEER_TRUSTED_CA_FILE=/etc/ssl/certs/etcd/peer-ca.crt"
+            Environment="ETCD_PEER_CERT_FILE=/etc/ssl/certs/etcd/peer.crt"
+            Environment="ETCD_PEER_KEY_FILE=/etc/ssl/certs/etcd/peer.key"
             Environment="ETCD_PEER_CLIENT_CERT_AUTH=true"
     - name: docker.service
       enable: true
@@ -30,7 +32,7 @@ systemd:
           contents: |
             [Service]
             Environment="REBOOT_STRATEGY=etcd-lock"
-            Environment="LOCKSMITHD_ETCD_CAFILE=/etc/ssl/etcd/etcd-ca.crt"
+            Environment="LOCKSMITHD_ETCD_CAFILE=/etc/ssl/etcd/etcd-client-ca.crt"
             Environment="LOCKSMITHD_ETCD_CERTFILE=/etc/ssl/etcd/etcd-client.crt"
             Environment="LOCKSMITHD_ETCD_KEYFILE=/etc/ssl/etcd/etcd-client.key"
             Environment="LOCKSMITHD_ENDPOINT={{.etcd_endpoints}}"
@@ -160,7 +162,7 @@ storage:
           # Wrapper for bootkube start
           set -e
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.4.5}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.5.0}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/opt/bootkube/assets}"
           exec /usr/bin/rkt run \
             --trust-keys-from-https \

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -9,7 +9,7 @@ systemd:
           contents: |
             [Service]
             Environment="REBOOT_STRATEGY=etcd-lock"
-            Environment="LOCKSMITHD_ETCD_CAFILE=/etc/ssl/etcd/etcd-ca.crt"
+            Environment="LOCKSMITHD_ETCD_CAFILE=/etc/ssl/etcd/etcd-client-ca.crt"
             Environment="LOCKSMITHD_ETCD_CERTFILE=/etc/ssl/etcd/etcd-client.crt"
             Environment="LOCKSMITHD_ETCD_KEYFILE=/etc/ssl/etcd/etcd-client.key"
             Environment="LOCKSMITHD_ENDPOINT={{.etcd_endpoints}}"


### PR DESCRIPTION
* Update non-terraform Kubernetes cluster to use [bootkube v0.5.0](https://github.com/kubernetes-incubator/bootkube/releases). Fix changes to etcd TLS generation.
* Increase Jenkinsfile timeouts to account for slow Quay downloads in the test environment, being addressed in #601

Similar to https://github.com/kubernetes-incubator/bootkube/pull/621