### PR TITLE
examples: Update terraform Kubernetes to use bootkube v0.5.0

### DIFF
--- a/examples/terraform/modules/bootkube/bootkube.tf
+++ b/examples/terraform/modules/bootkube/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/dghubble/bootkube-terraform.git?ref=v0.4.5"
+  source = "git::https://github.com/dghubble/bootkube-terraform.git?ref=v0.5.0"
 
   cluster_name                  = "${var.cluster_name}"
   api_servers                   = ["${var.k8s_domain_name}"]

--- a/examples/terraform/modules/bootkube/ssh.tf
+++ b/examples/terraform/modules/bootkube/ssh.tf
@@ -16,7 +16,7 @@ resource "null_resource" "copy-secrets" {
 
   provisioner "file" {
     content = "${module.bootkube.etcd_ca_cert}"
-    destination = "$HOME/etcd-ca.crt"
+    destination = "$HOME/etcd-client-ca.crt"
   }
 
   provisioner "file" {
@@ -27,6 +27,16 @@ resource "null_resource" "copy-secrets" {
   provisioner "file" {
     content = "${module.bootkube.etcd_client_key}"
     destination = "$HOME/etcd-client.key"
+  }
+
+  provisioner "file" {
+    content = "${module.bootkube.etcd_server_cert}"
+    destination = "$HOME/etcd-server.crt"
+  }
+
+  provisioner "file" {
+    content = "${module.bootkube.etcd_server_key}"
+    destination = "$HOME/etcd-server.key"
   }
 
   provisioner "file" {
@@ -41,8 +51,14 @@ resource "null_resource" "copy-secrets" {
 
   provisioner "remote-exec" {
     inline = [
-      "sudo mkdir -p /etc/ssl/etcd",
-      "sudo mv etcd-* /etc/ssl/etcd/",
+      "sudo mkdir -p /etc/ssl/etcd/etcd",
+      "sudo mv etcd-client* /etc/ssl/etcd/",
+      "sudo cp /etc/ssl/etcd/etcd-client-ca.crt /etc/ssl/etcd/etcd/server-ca.crt",
+      "sudo mv etcd-server.crt /etc/ssl/etcd/etcd/server.crt",
+      "sudo mv etcd-server.key /etc/ssl/etcd/etcd/server.key",
+      "sudo cp /etc/ssl/etcd/etcd-client-ca.crt /etc/ssl/etcd/etcd/peer-ca.crt",
+      "sudo mv etcd-peer.crt /etc/ssl/etcd/etcd/peer.crt",
+      "sudo mv etcd-peer.key /etc/ssl/etcd/etcd/peer.key",
       "sudo chown -R etcd:etcd /etc/ssl/etcd",
       "sudo chmod -R 500 /etc/ssl/etcd",
       "sudo mv /home/core/kubeconfig /etc/kubernetes/kubeconfig",

--- a/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
@@ -17,11 +17,13 @@ systemd:
             Environment="ETCD_INITIAL_CLUSTER={{.etcd_initial_cluster}}"
             Environment="ETCD_STRICT_RECONFIG_CHECK=true"
             Environment="ETCD_SSL_DIR=/etc/ssl/etcd"
-            Environment="ETCD_CERT_FILE=/etc/ssl/certs/etcd-client.crt"
-            Environment="ETCD_KEY_FILE=/etc/ssl/certs/etcd-client.key"
-            Environment="ETCD_PEER_CERT_FILE=/etc/ssl/certs/etcd-peer.crt"
-            Environment="ETCD_PEER_KEY_FILE=/etc/ssl/certs/etcd-peer.key"
-            Environment="ETCD_PEER_TRUSTED_CA_FILE=/etc/ssl/certs/etcd-ca.crt"
+            Environment="ETCD_TRUSTED_CA_FILE=/etc/ssl/certs/etcd/server-ca.crt"
+            Environment="ETCD_CERT_FILE=/etc/ssl/certs/etcd/server.crt"
+            Environment="ETCD_KEY_FILE=/etc/ssl/certs/etcd/server.key"
+            Environment="ETCD_CLIENT_CERT_AUTH=true"
+            Environment="ETCD_PEER_TRUSTED_CA_FILE=/etc/ssl/certs/etcd/peer-ca.crt"
+            Environment="ETCD_PEER_CERT_FILE=/etc/ssl/certs/etcd/peer.crt"
+            Environment="ETCD_PEER_KEY_FILE=/etc/ssl/certs/etcd/peer.key"
             Environment="ETCD_PEER_CLIENT_CERT_AUTH=true"
     {{ end }}
     - name: docker.service
@@ -32,7 +34,7 @@ systemd:
           contents: |
             [Service]
             Environment="REBOOT_STRATEGY=etcd-lock"
-            Environment="LOCKSMITHD_ETCD_CAFILE=/etc/ssl/etcd/etcd-ca.crt"
+            Environment="LOCKSMITHD_ETCD_CAFILE=/etc/ssl/etcd/etcd-client-ca.crt"
             Environment="LOCKSMITHD_ETCD_CERTFILE=/etc/ssl/etcd/etcd-client.crt"
             Environment="LOCKSMITHD_ETCD_KEYFILE=/etc/ssl/etcd/etcd-client.key"
             {{ if eq .etcd_on_host "false" -}}
@@ -166,7 +168,7 @@ storage:
           [ -d /opt/bootkube/assets/experimental/manifests ] && mv /opt/bootkube/assets/experimental/manifests/* /opt/bootkube/assets/manifests && rm -r /opt/bootkube/assets/experimental/manifests
           [ -d /opt/bootkube/assets/experimental/bootstrap-manifests ] && mv /opt/bootkube/assets/experimental/bootstrap-manifests/* /opt/bootkube/assets/bootstrap-manifests && rm -r /opt/bootkube/assets/experimental/bootstrap-manifests
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.4.5}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.5.0}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/opt/bootkube/assets}"
           exec /usr/bin/rkt run \
             --trust-keys-from-https \

--- a/examples/terraform/modules/profiles/cl/bootkube-worker.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/bootkube-worker.yaml.tmpl
@@ -9,7 +9,7 @@ systemd:
           contents: |
             [Service]
             Environment="REBOOT_STRATEGY=etcd-lock"
-            Environment="LOCKSMITHD_ETCD_CAFILE=/etc/ssl/etcd/etcd-ca.crt"
+            Environment="LOCKSMITHD_ETCD_CAFILE=/etc/ssl/etcd/etcd-client-ca.crt"
             Environment="LOCKSMITHD_ETCD_CERTFILE=/etc/ssl/etcd/etcd-client.crt"
             Environment="LOCKSMITHD_ETCD_KEYFILE=/etc/ssl/etcd/etcd-client.key"
             {{ if eq .etcd_on_host "false" -}}


### PR DESCRIPTION
* [Render changes](https://github.com/dghubble/bootkube-terraform/pull/5) corresponding to bootkube v0.5.0
* Manually tested cluster bootstrapping, with/without self-hosted etcd, and locksmithd updating the master and recovery. Looks good. Jenkins cluster tests may or may not pass, see #601 

Last part to #602 