### PR TITLE
check gpg-signatures before downloading, minimizing downloads

### DIFF
--- a/scripts/get-coreos
+++ b/scripts/get-coreos
@@ -43,22 +43,24 @@ curl -# https://coreos.com/security/image-signing-key/CoreOS_Image_Signing_Key.a
 $GPG --import < "$DEST/CoreOS_Image_Signing_Key.asc" || true
 
 # PXE kernel and sig
-echo "coreos_production_pxe.vmlinuz..."
-curl -# $BASE_URL/coreos_production_pxe.vmlinuz -o $DEST/coreos_production_pxe.vmlinuz
 echo "coreos_production_pxe.vmlinuz.sig"
 curl -# $BASE_URL/coreos_production_pxe.vmlinuz.sig -o $DEST/coreos_production_pxe.vmlinuz.sig
+echo "coreos_production_pxe.vmlinuz..."
+$GPG --verify $DEST/coreos_production_pxe.vmlinuz.sig || curl -# $BASE_URL/coreos_production_pxe.vmlinuz -o $DEST/coreos_production_pxe.vmlinuz
+
 
 # PXE initrd and sig
-echo "coreos_production_pxe_image.cpio.gz"
-curl -# $BASE_URL/coreos_production_pxe_image.cpio.gz -o $DEST/coreos_production_pxe_image.cpio.gz
 echo "coreos_production_pxe_image.cpio.gz.sig"
 curl -# $BASE_URL/coreos_production_pxe_image.cpio.gz.sig -o $DEST/coreos_production_pxe_image.cpio.gz.sig
+echo "coreos_production_pxe_image.cpio.gz"
+$GPG --verify $DEST/coreos_production_pxe_image.cpio.gz.sig || curl -# $BASE_URL/coreos_production_pxe_image.cpio.gz -o $DEST/coreos_production_pxe_image.cpio.gz
 
 # Install image
-echo "coreos_production_image.bin.bz2"
-curl -# $BASE_URL/coreos_production_image.bin.bz2 -o $DEST/coreos_production_image.bin.bz2
 echo "coreos_production_image.bin.bz2.sig"
 curl -# $BASE_URL/coreos_production_image.bin.bz2.sig -o $DEST/coreos_production_image.bin.bz2.sig
+echo "coreos_production_image.bin.bz2"
+$GPG --verify $DEST/coreos_production_image.bin.bz2.sig || curl -# $BASE_URL/coreos_production_image.bin.bz2 -o $DEST/coreos_production_image.bin.bz2
+
 
 # Install oem image
 if [[ -n "${IMAGE_NAME-}" ]]; then


### PR DESCRIPTION
Before the files would be downloaded every time the scripts was being run.
Now the gpg-signature will be downloaded and checked before downloading. 
Only if the gpg verification fails downloading starts.
