### PR TITLE
examples: Update Kubernetes to v1.7.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ Notable changes between releases.
 
 ### Examples / Modules
 
-* Upgrade Kubernetes v1.6.7 example clusters
+* Upgrade Kubernetes v1.7.1 example clusters
 * Kubernetes examples clusters enable etcd TLS
 * Deploy the Container Linux Update Operator (CLUO) to coordinate reboots of Container Linux nodes in Kubernetes clusters. See the cluster [addon docs](Documentation/cluster-addons.md).
 * Kubernetes examples (terraform and non-terraform) mask locksmithd

--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -1,6 +1,6 @@
-# Self-hosted Kubernetes
+# Kubernetes
 
-The self-hosted Kubernetes example provisions a 3 node "self-hosted" Kubernetes v1.6.7 cluster. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run once on a controller node to bootstrap Kubernetes control plane components as pods before exiting. An etcd3 cluster across controllers is used to back Kubernetes and coordinate Container Linux auto-updates (enabled for disk installs).
+The Kubernetes example provisions a 3 node "self-hosted" Kubernetes v1.7.1 cluster. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run once on a controller node to bootstrap Kubernetes control plane components as pods before exiting. An etcd3 cluster across controllers is used to back Kubernetes.
 
 ## Requirements
 
@@ -9,13 +9,13 @@ Ensure that you've gone through the [matchbox with rkt](getting-started-rkt.md) 
 * Use rkt or Docker to start `matchbox`
 * Create a network boot environment with `coreos/dnsmasq`
 * Create the example libvirt client VMs
-* `/etc/hosts` entries for `node[1-3].example.com` (or pass custom names to `k8s-certgen`)
+* `/etc/hosts` entries for `node[1-3].example.com`
 
-Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.5.1 and add it on your $PATH.
+Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.6.0 and add it on your $PATH.
 
 ```sh
 $ bootkube version
-Version: v0.5.1
+Version: v0.6.0
 ```
 
 ## Examples
@@ -106,9 +106,9 @@ $ ssh core@node1.example.com 'journalctl -f -u bootkube'
 $ export KUBECONFIG=assets/auth/kubeconfig
 $ kubectl get nodes
 NAME                STATUS    AGE       VERSION
-node1.example.com   Ready     7m        v1.6.7+coreos.0
-node2.example.com   Ready     7m        v1.6.7+coreos.0
-node3.example.com   Ready     7m        v1.6.7+coreos.0
+node1.example.com   Ready     11m       v1.7.1+coreos.0
+node2.example.com   Ready     11m       v1.7.1+coreos.0
+node3.example.com   Ready     11m       v1.7.1+coreos.0
 
 $ kubectl get pods --all-namespaces
 NAMESPACE     NAME                                       READY     STATUS    RESTARTS   AGE

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ Create [example](examples) clusters on-premise or locally with [QEMU/KVM](script
 
 * [simple-install](Documentation/getting-started.md) - Install Container Linux with an SSH key on all machines (beginner)
 * [etcd3](examples/terraform/etcd3-install/README.md) - Install a 3-node etcd3 cluster
-* [Kubernetes](examples/terraform/bootkube-install/README.md) - Install a 3-node self-hosted Kubernetes v1.6.7 cluster
+* [Kubernetes](examples/terraform/bootkube-install/README.md) - Install a 3-node self-hosted Kubernetes v1.7.1 cluster
 * Terraform [Modules](examples/terraform/modules) - Re-usable Terraform Modules
 
 **Manual**
 
 * [etcd3](Documentation/getting-started-rkt.md) - Install a 3-node etcd3 cluster
-* [Kubernetes](Documentation/bootkube.md) - Install a 3-node self-hosted Kubernetes v1.6.7 cluster
+* [Kubernetes](Documentation/bootkube.md) - Install a 3-node self-hosted Kubernetes v1.7.1 cluster
 
 ## Contrib
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ These examples use [Terraform](https://www.terraform.io/intro/) as a client to M
 |-------------------------------|-------------------------------|
 | [simple-install](terraform/simple-install) | Install Container Linux with an SSH key |
 | [etcd3-install](terraform/etcd3-install) | Install a 3-node etcd3 cluster |
-| [bootkube-install](terraform/bootkube-install) | Install a 3-node self-hosted Kubernetes v1.6.7 cluster |
+| [bootkube-install](terraform/bootkube-install) | Install a 3-node self-hosted Kubernetes v1.7.1 cluster |
 
 ### Customization
 
@@ -27,8 +27,8 @@ These examples mount raw Matchbox objects into a Matchbox server's `/var/lib/mat
 | grub | CoreOS Container Linux via GRUB2 Netboot | stable/1409.7.0 | RAM | NA |
 | etcd3 | PXE boot a 3 node etcd3 cluster with proxies | stable/1409.7.0 | RAM | None |
 | etcd3-install | Install a 3 node etcd3 cluster to disk | stable/1409.7.0 | Disk | None |
-| bootkube | PXE boot a self-hosted Kubernetes v1.6.7 cluster | stable/1409.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
-| bootkube-install | Install a self-hosted Kubernetes v1.6.7 cluster | stable/1409.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
+| bootkube | PXE boot a self-hosted Kubernetes v1.7.1 cluster | stable/1409.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
+| bootkube-install | Install a self-hosted Kubernetes v1.7.1 cluster | stable/1409.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
 
 ### Customization
 

--- a/examples/ignition/bootkube-controller.yaml
+++ b/examples/ignition/bootkube-controller.yaml
@@ -123,7 +123,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-          KUBELET_IMAGE_TAG=v1.6.7_coreos.0
+          KUBELET_IMAGE_TAG=v1.7.1_coreos.0
     - path: /etc/ssl/etcd/.empty
       filesystem: root
       mode: 0644
@@ -154,7 +154,7 @@ storage:
           # Wrapper for bootkube start
           set -e
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.5.1}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.6.0}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/opt/bootkube/assets}"
           exec /usr/bin/rkt run \
             --trust-keys-from-https \

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -92,7 +92,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-          KUBELET_IMAGE_TAG=v1.6.7_coreos.0
+          KUBELET_IMAGE_TAG=v1.7.1_coreos.0
     - path: /etc/ssl/etcd/.empty
       filesystem: root
       mode: 0644

--- a/examples/terraform/bootkube-install/README.md
+++ b/examples/terraform/bootkube-install/README.md
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes
 
-The self-hosted Kubernetes example shows how to use matchbox to network boot and provision a 3 node "self-hosted" Kubernetes v1.6.7 cluster. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run once on a controller node to bootstrap Kubernetes control plane components as pods before exiting.
+The self-hosted Kubernetes example shows how to use matchbox to network boot and provision a 3 node "self-hosted" Kubernetes v1.7.1 cluster. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run once on a controller node to bootstrap Kubernetes control plane components as pods before exiting.
 
 ## Requirements
 
@@ -128,10 +128,10 @@ $ sudo ./scripts/libvirt [start|reboot|shutdown|poweroff|destroy]
 ```sh
 $ export KUBECONFIG=assets/auth/kubeconfig
 $ kubectl get nodes
-NAME                STATUS    AGE
-node1.example.com   Ready     3m
-node2.example.com   Ready     3m
-node3.example.com   Ready     3m
+NAME                STATUS    AGE       VERSION
+node1.example.com   Ready     11m       v1.7.1+coreos.0
+node2.example.com   Ready     11m       v1.7.1+coreos.0
+node3.example.com   Ready     11m       v1.7.1+coreos.0
 
 $ kubectl get pods --all-namespaces
 NAMESPACE     NAME                                       READY     STATUS    RESTARTS   AGE

--- a/examples/terraform/modules/bootkube/bootkube.tf
+++ b/examples/terraform/modules/bootkube/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/dghubble/bootkube-terraform.git?ref=v0.5.1"
+  source = "git::https://github.com/dghubble/bootkube-terraform.git?ref=v0.6.0"
 
   cluster_name                  = "${var.cluster_name}"
   api_servers                   = ["${var.k8s_domain_name}"]

--- a/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
@@ -128,7 +128,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-          KUBELET_IMAGE_TAG=v1.6.7_coreos.0
+          KUBELET_IMAGE_TAG=v1.7.1_coreos.0
     - path: /etc/hostname
       filesystem: root
       mode: 0644
@@ -156,7 +156,7 @@ storage:
           [ -d /opt/bootkube/assets/experimental/manifests ] && mv /opt/bootkube/assets/experimental/manifests/* /opt/bootkube/assets/manifests && rm -r /opt/bootkube/assets/experimental/manifests
           [ -d /opt/bootkube/assets/experimental/bootstrap-manifests ] && mv /opt/bootkube/assets/experimental/bootstrap-manifests/* /opt/bootkube/assets/bootstrap-manifests && rm -r /opt/bootkube/assets/experimental/bootstrap-manifests
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.5.1}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.6.0}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/opt/bootkube/assets}"
           exec /usr/bin/rkt run \
             --trust-keys-from-https \

--- a/examples/terraform/modules/profiles/cl/bootkube-worker.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/bootkube-worker.yaml.tmpl
@@ -92,7 +92,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-          KUBELET_IMAGE_TAG=v1.6.7_coreos.0
+          KUBELET_IMAGE_TAG=v1.7.1_coreos.0
     - path: /etc/hostname
       filesystem: root
       mode: 0644

--- a/scripts/dev/get-bootkube
+++ b/scripts/dev/get-bootkube
@@ -4,7 +4,7 @@
 set -eu
 
 DEST=${1:-"bin"}
-VERSION="v0.5.1"
+VERSION="v0.6.0"
 
 URL="https://github.com/kubernetes-incubator/bootkube/releases/download/${VERSION}/bootkube.tar.gz"
 

--- a/scripts/dev/get-kubectl
+++ b/scripts/dev/get-kubectl
@@ -4,7 +4,7 @@
 set -eu
 
 DEST=${1:-"bin"}
-VERSION="v1.6.7"
+VERSION="v1.7.1"
 
 URL="https://storage.googleapis.com/kubernetes-release/release/${VERSION}/bin/linux/amd64/kubectl"
 


### PR DESCRIPTION
Update Kubernetes cluster examples and Terraform modules for v1.7.1. Use or target bootkube v0.6.0 asset generation:

* `bootkube render` (https://github.com/kubernetes-incubator/bootkube/releases/tag/v0.6.0)
* bootkube-terraform module - https://github.com/dghubble/bootkube-terraform/pull/7