### PR TITLE
Add handling of current to get-coreos script

### DIFF
--- a/scripts/get-coreos
+++ b/scripts/get-coreos
@@ -9,71 +9,74 @@ set -eou pipefail
 GPG=${GPG:-/usr/bin/gpg}
 
 CHANNEL=${1:-"stable"}
-VERSION=${2:-"1409.7.0"}
+COREOS_VERSION_ID=${2:-"1409.7.0"}
 DEST_DIR=${3:-"$PWD/examples/assets"}
 OEM_ID=${OEM_ID:-""}
-DEST=$DEST_DIR/coreos/$VERSION
-BASE_URL=https://$CHANNEL.release.core-os.net/amd64-usr/$VERSION
+BASE_URL=https://${CHANNEL}.release.core-os.net/amd64-usr/${COREOS_VERSION_ID}
 
 # check channel/version exist based on the header response
-if ! curl -s -I $BASE_URL/coreos_production_pxe.vmlinuz | grep -q -E '^HTTP/[0-9.]+ [23][0-9][0-9]' ; then
-  echo "Channel or Version not found"
+if ! $(curl -s -I ${BASE_URL}/version.txt | grep -q -E '^HTTP/[0-9.]+ [23][0-9][0-9]')>/dev/null ; then
+  echo "version not found"
   exit 1
 fi
 
-if [ ! -d "$DEST" ]; then
-  echo "Creating directory $DEST"
-  mkdir -p $DEST
+export $(curl  -sS ${BASE_URL}/version.txt 2>/dev/null | grep COREOS_VERSION_ID)
+
+DEST=${DEST_DIR}/coreos/${COREOS_VERSION_ID}
+if [ ! -d "${DEST}" ]; then
+  echo "Creating directory ${DEST}"
+  mkdir -p ${DEST}
 fi
 
 if [[ -n "${OEM_ID}" ]]; then
   IMAGE_NAME="coreos_production_${OEM_ID}_image.bin.bz2"
 
   # check if the oem version exists based on the header response
-  if ! curl -s -I $BASE_URL/$IMAGE_NAME | grep -q -E '^HTTP/[0-9.]+ [23][0-9][0-9]' ; then
+  if ! curl -s -I ${BASE_URL}/${IMAGE_NAME} | grep -q -E '^HTTP/[0-9.]+ [23][0-9][0-9]' ; then
     echo "OEM version not found"
     exit 1
   fi
 fi
 
-echo "Downloading CoreOS $CHANNEL $VERSION images and sigs to $DEST"
+
+echo "Downloading CoreOS ${CHANNEL} ${COREOS_VERSION_ID} images and sigs to ${DEST}"
 
 echo "CoreOS Image Signing Key"
-curl -# https://coreos.com/security/image-signing-key/CoreOS_Image_Signing_Key.asc -o $DEST/CoreOS_Image_Signing_Key.asc
-$GPG --import < "$DEST/CoreOS_Image_Signing_Key.asc" || true
+curl -# https://coreos.com/security/image-signing-key/CoreOS_Image_Signing_Key.asc -o ${DEST}/CoreOS_Image_Signing_Key.asc
+${GPG} --import < "${DEST}/CoreOS_Image_Signing_Key.asc" || true
 
 # PXE kernel and sig
 echo "coreos_production_pxe.vmlinuz..."
-curl -# $BASE_URL/coreos_production_pxe.vmlinuz -o $DEST/coreos_production_pxe.vmlinuz
+curl -# ${BASE_URL}/coreos_production_pxe.vmlinuz -o ${DEST}/coreos_production_pxe.vmlinuz
 echo "coreos_production_pxe.vmlinuz.sig"
-curl -# $BASE_URL/coreos_production_pxe.vmlinuz.sig -o $DEST/coreos_production_pxe.vmlinuz.sig
+curl -# ${BASE_URL}/coreos_production_pxe.vmlinuz.sig -o ${DEST}/coreos_production_pxe.vmlinuz.sig
 
 # PXE initrd and sig
 echo "coreos_production_pxe_image.cpio.gz"
-curl -# $BASE_URL/coreos_production_pxe_image.cpio.gz -o $DEST/coreos_production_pxe_image.cpio.gz
+curl -# ${BASE_URL}/coreos_production_pxe_image.cpio.gz -o ${DEST}/coreos_production_pxe_image.cpio.gz
 echo "coreos_production_pxe_image.cpio.gz.sig"
-curl -# $BASE_URL/coreos_production_pxe_image.cpio.gz.sig -o $DEST/coreos_production_pxe_image.cpio.gz.sig
+curl -# ${BASE_URL}/coreos_production_pxe_image.cpio.gz.sig -o ${DEST}/coreos_production_pxe_image.cpio.gz.sig
 
 # Install image
 echo "coreos_production_image.bin.bz2"
-curl -# $BASE_URL/coreos_production_image.bin.bz2 -o $DEST/coreos_production_image.bin.bz2
+curl -# ${BASE_URL}/coreos_production_image.bin.bz2 -o ${DEST}/coreos_production_image.bin.bz2
 echo "coreos_production_image.bin.bz2.sig"
-curl -# $BASE_URL/coreos_production_image.bin.bz2.sig -o $DEST/coreos_production_image.bin.bz2.sig
+curl -# ${BASE_URL}/coreos_production_image.bin.bz2.sig -o ${DEST}/coreos_production_image.bin.bz2.sig
 
 # Install oem image
 if [[ -n "${IMAGE_NAME-}" ]]; then
-  echo $IMAGE_NAME
-  curl -# $BASE_URL/$IMAGE_NAME -o $DEST/$IMAGE_NAME
-  echo "$IMAGE_NAME.sig"
-  curl -# $BASE_URL/$IMAGE_NAME.sig -o $DEST/$IMAGE_NAME.sig
+  echo ${IMAGE_NAME}
+  curl -# ${BASE_URL}/${IMAGE_NAME} -o ${DEST}/${IMAGE_NAME}
+  echo "${IMAGE_NAME}.sig"
+  curl -# ${BASE_URL}/${IMAGE_NAME}.sig -o ${DEST}/${IMAGE_NAME}.sig
 fi
 
 # verify signatures
-$GPG --verify $DEST/coreos_production_pxe.vmlinuz.sig
-$GPG --verify $DEST/coreos_production_pxe_image.cpio.gz.sig
-$GPG --verify $DEST/coreos_production_image.bin.bz2.sig
+$GPG --verify ${DEST}/coreos_production_pxe.vmlinuz.sig
+$GPG --verify ${DEST}/coreos_production_pxe_image.cpio.gz.sig
+$GPG --verify ${DEST}/coreos_production_image.bin.bz2.sig
 
 # verify oem signature
 if [[ -n "${IMAGE_NAME-}" ]]; then
-  $GPG --verify $DEST/$IMAGE_NAME.sig
+  ${GPG} --verify ${DEST}/${IMAGE_NAME}.sig
 fi


### PR DESCRIPTION
* Adds logic to get-coreos script such that you can provide it with:
```
get-coreos stable current .
```

and it will place the downloaded image into a directory named for the
version. This helps with tectonic as tectonic expects that the
downloaded image is named for the version rather than "current"