### PR TITLE
contrib/dnsmasq: Bump dnsmasq image to v0.4.1

### DIFF
--- a/contrib/dnsmasq/Dockerfile
+++ b/contrib/dnsmasq/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.5
+FROM alpine:3.6
 MAINTAINER Dalton Hubble <dalton.hubble@coreos.com>
 RUN apk -U add dnsmasq curl
 COPY tftpboot /var/lib/tftpboot
-EXPOSE 53
+EXPOSE 53 67 69
 ENTRYPOINT ["/usr/sbin/dnsmasq"]

--- a/contrib/dnsmasq/Makefile
+++ b/contrib/dnsmasq/Makefile
@@ -1,4 +1,4 @@
-VERSION=v0.4.0
+VERSION=v0.4.1
 
 IMAGE_REPO=coreos/dnsmasq
 QUAY_REPO=quay.io/coreos/dnsmasq


### PR DESCRIPTION
* Update from alpine:3.5 to alpine:3.6
* List ports 67 and 69 so ACI conversion still works

Related to #620 