### PR TITLE
Documentation: remove ETCDCTL_API=3 settings

### DIFF
--- a/Documentation/getting-started-docker.md
+++ b/Documentation/getting-started-docker.md
@@ -107,7 +107,6 @@ The example profile added autologin so you can verify that etcd3 works between n
 
 ```sh
 $ systemctl status etcd-member
-$ export ETCDCTL_API=3
 $ etcdctl set /message hello
 $ etcdctl get /message
 ```

--- a/Documentation/getting-started-rkt.md
+++ b/Documentation/getting-started-rkt.md
@@ -158,7 +158,6 @@ The example profile added autologin so you can verify that etcd3 works between n
 
 ```sh
 $ systemctl status etcd-member
-$ export ETCDCTL_API=3
 $ etcdctl set /message hello
 $ etcdctl get /message
 ```

--- a/examples/terraform/etcd3-install/README.md
+++ b/examples/terraform/etcd3-install/README.md
@@ -93,7 +93,6 @@ $ systemctl status etcd-member
 Verify that etcd3 peers are healthy and communicating.
 
 ```sh
-$ export ETCDCTL_API=3
 $ etcdctl cluster-health
 $ etcdctl set /message hello
 $ etcdctl get /message


### PR DESCRIPTION
etcd examples set ETCDCTL_API=3 but are using v2 etcdctl commands. This
works on CL by accident because it ships with 2.3 so etcdctl doesn't
recognize the API env var.