### PR TITLE
matchbox/client: Validate client endpoint is a host:port

### DIFF
--- a/matchbox/client/client.go
+++ b/matchbox/client/client.go
@@ -3,6 +3,8 @@ package client
 import (
 	"crypto/tls"
 	"errors"
+	"fmt"
+	"net"
 	"time"
 
 	"google.golang.org/grpc"
@@ -39,6 +41,11 @@ type Client struct {
 func New(config *Config) (*Client, error) {
 	if len(config.Endpoints) == 0 {
 		return nil, errNoEndpoints
+	}
+	for _, endpoint := range config.Endpoints {
+		if _, _, err := net.SplitHostPort(endpoint); err != nil {
+			return nil, fmt.Errorf("client: invalid host:port endpoint: %v", err)
+		}
 	}
 	return newClient(config)
 }

--- a/matchbox/client/client_test.go
+++ b/matchbox/client/client_test.go
@@ -14,3 +14,20 @@ func TestNew_MissingEndpoints(t *testing.T) {
 	assert.Nil(t, client)
 	assert.Equal(t, errNoEndpoints, err)
 }
+
+// gRPC expects host:port with no scheme (e.g. matchbox.example.com:8081)
+func TestNew_InvalidEndpoints(t *testing.T) {
+	invalid := []string{
+		"matchbox.example.com",
+		"http://matchbox.example.com:8081",
+		"https://matchbox.example.com:8081",
+	}
+
+	for _, endpoint := range invalid {
+		client, err := New(&Config{
+			Endpoints: []string{endpoint},
+		})
+		assert.Nil(t, client)
+		assert.Error(t, err)
+	}
+}


### PR DESCRIPTION
* Provide better errors to clients that forget to specify the port or include a protocol scheme by mistake
* grpc-go uses net.SplitHostPort to validate server listener addresses are 'host:port' but doesn't validate Dial targets. https://github.com/grpc/grpc-go/blob/e81b5698fd6a1fdbae0c62f52e9aabdeee231b99/clientconn.go#L304
* Validating our clients provide a host:port is a simple sanity check / pass filter, it is by no means complete. Properly validating a client target depends on the resolver, see https://github.com/grpc/grpc-go/issues/1346.

Before, in a client like `terraform-provider-matchbox`, invalid endpoints produced:

```
failed to create Matchbox client or connect to https://matchbox.example.com:8081: context deadline exceeded
```

Its not very helpful if you don't know the format is host:port. Once this change is pulled in, the messages will be more like:

```
failed to create Matchbox client or connect to matchbox.example.com: client: invalid host:port endpoint: missing port in address matchbox.example.com
failed to create Matchbox client or connect to https://matchbox.example.com8081: client: invalid host:port endpoint: too many colons in address https://matchbox.example.com:8081
```

cc @cehoffman
Closes #633 