### PR TITLE
Add version.txt download on get-coreos

### DIFF
--- a/scripts/get-coreos
+++ b/scripts/get-coreos
@@ -42,6 +42,10 @@ echo "CoreOS Image Signing Key"
 curl -# https://coreos.com/security/image-signing-key/CoreOS_Image_Signing_Key.asc -o $DEST/CoreOS_Image_Signing_Key.asc
 $GPG --import < "$DEST/CoreOS_Image_Signing_Key.asc" || true
 
+# Version
+echo "version.txt"
+curl -# $BASE_URL/version.txt -o $DEST/version.txt
+
 # PXE kernel and sig
 echo "coreos_production_pxe.vmlinuz..."
 curl -# $BASE_URL/coreos_production_pxe.vmlinuz -o $DEST/coreos_production_pxe.vmlinuz


### PR DESCRIPTION
The `version.txt` file is used by coreos-install if the version number is `current`.