### PR TITLE
Fix for "(23) Failed writing body" on get-coreos

### DIFF
--- a/scripts/get-coreos
+++ b/scripts/get-coreos
@@ -16,7 +16,7 @@ DEST=$DEST_DIR/coreos/$VERSION
 BASE_URL=https://$CHANNEL.release.core-os.net/amd64-usr/$VERSION
 
 # check channel/version exist based on the header response
-if ! curl -s -I $BASE_URL/coreos_production_pxe.vmlinuz | grep -q -E '^HTTP/[0-9.]+ [23][0-9][0-9]' ; then
+if ! curl -s -I $BASE_URL/coreos_production_pxe.vmlinuz | tac | tac | grep -q -E '^HTTP/[0-9.]+ [23][0-9][0-9]' ; then
   echo "Channel or Version not found"
   exit 1
 fi


### PR DESCRIPTION
Fix for #637 

Curl expects output stream to be open, but `grep -q` closes it right after it found a match.
Solution is to read all the curl output before passing it to grep.