### PR TITLE
examples: Update Kubernetes from v1.7.1 to v1.7.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ Notable changes between releases.
 
 ### Examples / Modules
 
-* Upgrade Kubernetes v1.7.1 example clusters
+* Upgrade Kubernetes v1.7.3 example clusters
 * Kubernetes examples clusters enable etcd TLS
 * Deploy the Container Linux Update Operator (CLUO) to coordinate reboots of Container Linux nodes in Kubernetes clusters. See the cluster [addon docs](Documentation/cluster-addons.md).
 * Kubernetes examples (terraform and non-terraform) mask locksmithd

--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -1,6 +1,6 @@
 # Kubernetes
 
-The Kubernetes example provisions a 3 node "self-hosted" Kubernetes v1.7.1 cluster. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run once on a controller node to bootstrap Kubernetes control plane components as pods before exiting. An etcd3 cluster across controllers is used to back Kubernetes.
+The Kubernetes example provisions a 3 node "self-hosted" Kubernetes v1.7.3 cluster. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run once on a controller node to bootstrap Kubernetes control plane components as pods before exiting. An etcd3 cluster across controllers is used to back Kubernetes.
 
 ## Requirements
 
@@ -11,11 +11,11 @@ Ensure that you've gone through the [matchbox with rkt](getting-started-rkt.md) 
 * Create the example libvirt client VMs
 * `/etc/hosts` entries for `node[1-3].example.com`
 
-Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.6.0 and add it on your $PATH.
+Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.6.1 and add it on your $PATH.
 
 ```sh
 $ bootkube version
-Version: v0.6.0
+Version: v0.6.1
 ```
 
 ## Examples
@@ -106,9 +106,9 @@ $ ssh core@node1.example.com 'journalctl -f -u bootkube'
 $ export KUBECONFIG=assets/auth/kubeconfig
 $ kubectl get nodes
 NAME                STATUS    AGE       VERSION
-node1.example.com   Ready     11m       v1.7.1+coreos.0
-node2.example.com   Ready     11m       v1.7.1+coreos.0
-node3.example.com   Ready     11m       v1.7.1+coreos.0
+node1.example.com   Ready     11m       v1.7.3+coreos.0
+node2.example.com   Ready     11m       v1.7.3+coreos.0
+node3.example.com   Ready     11m       v1.7.3+coreos.0
 
 $ kubectl get pods --all-namespaces
 NAMESPACE     NAME                                       READY     STATUS    RESTARTS   AGE

--- a/README.md
+++ b/README.md
@@ -24,32 +24,22 @@
 
 ### Tutorials
 
-* [Getting Started](Documentation/getting-started.md)
+* [Getting Started](Documentation/getting-started.md) - provision Container Linux machines (beginner)
 * Local QEMU/KVM
     * [matchbox with rkt](Documentation/getting-started-rkt.md)
     * [matchbox with Docker](Documentation/getting-started-docker.md)
-
-### Example Clusters
-
-Create [example](examples) clusters on-premise or locally with [QEMU/KVM](scripts/README.md#libvirt).
-
-**Terraform-based**
-
-* [simple-install](Documentation/getting-started.md) - Install Container Linux with an SSH key on all machines (beginner)
-* [etcd3](examples/terraform/etcd3-install/README.md) - Install a 3-node etcd3 cluster
-* [Kubernetes](examples/terraform/bootkube-install/README.md) - Install a 3-node self-hosted Kubernetes v1.7.1 cluster
-* Terraform [Modules](examples/terraform/modules) - Re-usable Terraform Modules
-
-**Manual**
-
-* [etcd3](Documentation/getting-started-rkt.md) - Install a 3-node etcd3 cluster
-* [Kubernetes](Documentation/bootkube.md) - Install a 3-node self-hosted Kubernetes v1.7.1 cluster
+* Clusters
+  * [etcd3](Documentation/getting-started-rkt.md) - Install a 3-node etcd3 cluster
+  * [Kubernetes](Documentation/bootkube.md) - Install a 3-node self-hosted Kubernetes v1.7.3 cluster
+* Clusters (Terraform-based)
+  * [etcd3](examples/terraform/etcd3-install/README.md) - Install a 3-node etcd3 cluster
+  * [Kubernetes](examples/terraform/bootkube-install/README.md) - Install a 3-node self-hosted Kubernetes v1.7.3 cluster
 
 ## Contrib
 
 * [dnsmasq](contrib/dnsmasq/README.md) - Run DHCP, TFTP, and DNS services with docker or rkt
 * [squid](contrib/squid/README.md) - Run a transparent cache proxy
-* [terraform-provider-matchbox](https://github.com/coreos/terraform-provider-matchbox) - Terraform plugin which supports "matchbox" provider
+* [terraform-provider-matchbox](https://github.com/coreos/terraform-provider-matchbox) - Terraform provider plugin for Matchbox
 
 [docs]: https://coreos.com/matchbox/docs/latest
 [terraform]: https://github.com/coreos/terraform-provider-matchbox

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ These examples use [Terraform](https://www.terraform.io/intro/) as a client to M
 |-------------------------------|-------------------------------|
 | [simple-install](terraform/simple-install) | Install Container Linux with an SSH key |
 | [etcd3-install](terraform/etcd3-install) | Install a 3-node etcd3 cluster |
-| [bootkube-install](terraform/bootkube-install) | Install a 3-node self-hosted Kubernetes v1.7.1 cluster |
+| [bootkube-install](terraform/bootkube-install) | Install a 3-node self-hosted Kubernetes v1.7.3 cluster |
 
 ### Customization
 
@@ -27,8 +27,8 @@ These examples mount raw Matchbox objects into a Matchbox server's `/var/lib/mat
 | grub | CoreOS Container Linux via GRUB2 Netboot | stable/1409.7.0 | RAM | NA |
 | etcd3 | PXE boot a 3 node etcd3 cluster with proxies | stable/1409.7.0 | RAM | None |
 | etcd3-install | Install a 3 node etcd3 cluster to disk | stable/1409.7.0 | Disk | None |
-| bootkube | PXE boot a self-hosted Kubernetes v1.7.1 cluster | stable/1409.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
-| bootkube-install | Install a self-hosted Kubernetes v1.7.1 cluster | stable/1409.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
+| bootkube | PXE boot a self-hosted Kubernetes v1.7.3 cluster | stable/1409.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
+| bootkube-install | Install a self-hosted Kubernetes v1.7.3 cluster | stable/1409.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
 
 ### Customization
 

--- a/examples/ignition/bootkube-controller.yaml
+++ b/examples/ignition/bootkube-controller.yaml
@@ -123,7 +123,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-          KUBELET_IMAGE_TAG=v1.7.1_coreos.0
+          KUBELET_IMAGE_TAG=v1.7.3_coreos.0
     - path: /etc/ssl/etcd/.empty
       filesystem: root
       mode: 0644
@@ -154,7 +154,7 @@ storage:
           # Wrapper for bootkube start
           set -e
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.6.0}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.6.1}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/opt/bootkube/assets}"
           exec /usr/bin/rkt run \
             --trust-keys-from-https \

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -92,7 +92,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-          KUBELET_IMAGE_TAG=v1.7.1_coreos.0
+          KUBELET_IMAGE_TAG=v1.7.3_coreos.0
     - path: /etc/ssl/etcd/.empty
       filesystem: root
       mode: 0644

--- a/examples/terraform/bootkube-install/README.md
+++ b/examples/terraform/bootkube-install/README.md
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes
 
-The self-hosted Kubernetes example shows how to use matchbox to network boot and provision a 3 node "self-hosted" Kubernetes v1.7.1 cluster. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run once on a controller node to bootstrap Kubernetes control plane components as pods before exiting.
+The self-hosted Kubernetes example shows how to use matchbox to network boot and provision a 3 node "self-hosted" Kubernetes v1.7.3 cluster. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run once on a controller node to bootstrap Kubernetes control plane components as pods before exiting.
 
 ## Requirements
 
@@ -129,9 +129,9 @@ $ sudo ./scripts/libvirt [start|reboot|shutdown|poweroff|destroy]
 $ export KUBECONFIG=assets/auth/kubeconfig
 $ kubectl get nodes
 NAME                STATUS    AGE       VERSION
-node1.example.com   Ready     11m       v1.7.1+coreos.0
-node2.example.com   Ready     11m       v1.7.1+coreos.0
-node3.example.com   Ready     11m       v1.7.1+coreos.0
+node1.example.com   Ready     11m       v1.7.3+coreos.0
+node2.example.com   Ready     11m       v1.7.3+coreos.0
+node3.example.com   Ready     11m       v1.7.3+coreos.0
 
 $ kubectl get pods --all-namespaces
 NAMESPACE     NAME                                       READY     STATUS    RESTARTS   AGE

--- a/examples/terraform/modules/bootkube/bootkube.tf
+++ b/examples/terraform/modules/bootkube/bootkube.tf
@@ -1,6 +1,6 @@
 # Self-hosted Kubernetes assets (kubeconfig, manifests)
 module "bootkube" {
-  source = "git::https://github.com/poseidon/bootkube-terraform.git?ref=v0.6.0"
+  source = "git::https://github.com/poseidon/bootkube-terraform.git?ref=v0.6.1"
 
   cluster_name                  = "${var.cluster_name}"
   api_servers                   = ["${var.k8s_domain_name}"]

--- a/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
@@ -128,7 +128,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-          KUBELET_IMAGE_TAG=v1.7.1_coreos.0
+          KUBELET_IMAGE_TAG=v1.7.3_coreos.0
     - path: /etc/hostname
       filesystem: root
       mode: 0644
@@ -156,7 +156,7 @@ storage:
           [ -d /opt/bootkube/assets/experimental/manifests ] && mv /opt/bootkube/assets/experimental/manifests/* /opt/bootkube/assets/manifests && rm -r /opt/bootkube/assets/experimental/manifests
           [ -d /opt/bootkube/assets/experimental/bootstrap-manifests ] && mv /opt/bootkube/assets/experimental/bootstrap-manifests/* /opt/bootkube/assets/bootstrap-manifests && rm -r /opt/bootkube/assets/experimental/bootstrap-manifests
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.6.0}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.6.1}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/opt/bootkube/assets}"
           exec /usr/bin/rkt run \
             --trust-keys-from-https \

--- a/examples/terraform/modules/profiles/cl/bootkube-worker.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/bootkube-worker.yaml.tmpl
@@ -92,7 +92,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-          KUBELET_IMAGE_TAG=v1.7.1_coreos.0
+          KUBELET_IMAGE_TAG=v1.7.3_coreos.0
     - path: /etc/hostname
       filesystem: root
       mode: 0644

--- a/scripts/dev/get-bootkube
+++ b/scripts/dev/get-bootkube
@@ -4,7 +4,7 @@
 set -eu
 
 DEST=${1:-"bin"}
-VERSION="v0.6.0"
+VERSION="v0.6.1"
 
 URL="https://github.com/kubernetes-incubator/bootkube/releases/download/${VERSION}/bootkube.tar.gz"
 

--- a/scripts/dev/get-kubectl
+++ b/scripts/dev/get-kubectl
@@ -4,7 +4,7 @@
 set -eu
 
 DEST=${1:-"bin"}
-VERSION="v1.7.1"
+VERSION="v1.7.3"
 
 URL="https://storage.googleapis.com/kubernetes-release/release/${VERSION}/bin/linux/amd64/kubectl"
 


### PR DESCRIPTION
Update Kubernetes cluster examples (terraform-based and non) for Kubernetes v1.7.3.

~CI requires the bootkube binary be published: https://github.com/kubernetes-incubator/bootkube/issues/690~