### PR TITLE
libvirt: don't pass --pxe

### DIFF
--- a/Documentation/grub.md
+++ b/Documentation/grub.md
@@ -62,5 +62,5 @@ $ sudo docker run --rm --cap-add=NET_ADMIN quay.io/coreos/dnsmasq -d -q --dhcp-r
 Create a VM to verify the machine network boots.
 
 ```sh
-$ sudo virt-install --name uefi-test --pxe --boot=uefi,network --disk pool=default,size=4 --network=bridge=docker0,model=e1000 --memory=1024 --vcpus=1 --os-type=linux --noautoconsole
+$ sudo virt-install --name uefi-test --boot=uefi,network --disk pool=default,size=4 --network=bridge=docker0,model=e1000 --memory=1024 --vcpus=1 --os-type=linux --noautoconsole
 ```

--- a/scripts/libvirt
+++ b/scripts/libvirt
@@ -41,7 +41,7 @@ function usage {
   echo -e "\tdestroy\t\tdestroy the QEMU/KVM nodes"
 }
 
-COMMON_VIRT_OPTS="--memory=${VM_MEMORY} --vcpus=1 --pxe --disk pool=default,size=${VM_DISK} --os-type=linux --os-variant=generic --noautoconsole --events on_poweroff=preserve"
+COMMON_VIRT_OPTS="--memory=${VM_MEMORY} --vcpus=1 --disk pool=default,size=${VM_DISK} --os-type=linux --os-variant=generic --noautoconsole --events on_poweroff=preserve"
 
 NODE1_NAME=node1
 NODE1_MAC=52:54:00:a1:9c:ae


### PR DESCRIPTION
In virt-install v1.4.2, the meaning of  `--pxe` changed from "allow pxe boot" to "always pxe boot." This breaks matchbox, since we expect hosts to pxe-boot only with empty hds. On hosts with v1.4.2, the VMs loop, re-installing CL over and over.

The flag isn't necessary anyways, since we pass `--boot=hd,network`, which enables pxe-booting.

[This](https://github.com/virt-manager/virt-manager/commit/ff3b4dc5b0b21393dbccc0f5f691b17bf1a761bd) is the offending virt-manager commit.