### PR TITLE
matchbox/client: Expose Select endpoint

### DIFF
--- a/matchbox/client/client.go
+++ b/matchbox/client/client.go
@@ -34,6 +34,7 @@ type Client struct {
 	Profiles rpcpb.ProfilesClient
 	Ignition rpcpb.IgnitionClient
 	Generic  rpcpb.GenericClient
+	Select   rpcpb.SelectClient
 	conn     *grpc.ClientConn
 }
 
@@ -66,6 +67,7 @@ func newClient(config *Config) (*Client, error) {
 		Profiles: rpcpb.NewProfilesClient(conn),
 		Ignition: rpcpb.NewIgnitionClient(conn),
 		Generic:  rpcpb.NewGenericClient(conn),
+		Select:   rpcpb.NewSelectClient(conn),
 	}
 	return client, nil
 }


### PR DESCRIPTION
Exposes the Select endpoint in matchbox/client just as the other
endpoints like Profiles, Ignition and Generic.

I might have missed if there is a reason for this not to be exposed, but I wanted the ability to lookup a profile based on e.g. a MAC-address (like the /grub HTTP API does).