### PR TITLE
bootkube calico support move assets_dir/manifests-networking to assets_dir/manifests

### DIFF
--- a/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
+++ b/examples/terraform/modules/profiles/cl/bootkube-controller.yaml.tmpl
@@ -155,6 +155,7 @@ storage:
           # Move experimental manifests
           [ -d /opt/bootkube/assets/experimental/manifests ] && mv /opt/bootkube/assets/experimental/manifests/* /opt/bootkube/assets/manifests && rm -r /opt/bootkube/assets/experimental/manifests
           [ -d /opt/bootkube/assets/experimental/bootstrap-manifests ] && mv /opt/bootkube/assets/experimental/bootstrap-manifests/* /opt/bootkube/assets/bootstrap-manifests && rm -r /opt/bootkube/assets/experimental/bootstrap-manifests
+          [ -d /opt/bootkube/assets/manifests-networking ] && mv /opt/bootkube/assets/manifests-networking/* /opt/bootkube/assets/manifests && rm -r /opt/bootkube/assets/manifests-networking
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
           BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.6.1}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/opt/bootkube/assets}"


### PR DESCRIPTION
As noted in bootkube-terraform, this step must be done for new networking support

https://github.com/poseidon/bootkube-terraform/commit/a52f99e8cc8b395cf2b28f74a9f79c01b63e99ae