### PR TITLE
examples: Update Kubernetes from v1.7.5 to v1.7.7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Notable changes between releases.
 
 ### Examples / Modules
 
-* Upgrade Kubernetes v1.7.5 example clusters
+* Upgrade Kubernetes v1.7.7 example clusters
 * Kubernetes examples clusters enable etcd TLS
 * Deploy the Container Linux Update Operator (CLUO) to coordinate reboots of Container Linux nodes in Kubernetes clusters. See the cluster [addon docs](Documentation/cluster-addons.md).
 * Kubernetes examples (terraform and non-terraform) mask locksmithd

--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -1,6 +1,6 @@
 # Kubernetes
 
-The Kubernetes example provisions a 3 node Kubernetes v1.7.5 cluster. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run once on a controller node to bootstrap Kubernetes control plane components as pods before exiting. An etcd3 cluster across controllers is used to back Kubernetes.
+The Kubernetes example provisions a 3 node Kubernetes v1.7.7 cluster. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run once on a controller node to bootstrap Kubernetes control plane components as pods before exiting. An etcd3 cluster across controllers is used to back Kubernetes.
 
 ## Requirements
 
@@ -11,11 +11,11 @@ Ensure that you've gone through the [matchbox with rkt](getting-started-rkt.md) 
 * Create the example libvirt client VMs
 * `/etc/hosts` entries for `node[1-3].example.com`
 
-Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.6.2 and add it on your $PATH.
+Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.7.0 and add it on your $PATH.
 
 ```sh
 $ bootkube version
-Version: v0.6.2
+Version: v0.7.0
 ```
 
 ## Examples
@@ -106,9 +106,9 @@ $ ssh core@node1.example.com 'journalctl -f -u bootkube'
 $ export KUBECONFIG=assets/auth/kubeconfig
 $ kubectl get nodes
 NAME                STATUS    AGE       VERSION
-node1.example.com   Ready     11m       v1.7.5+coreos.0
-node2.example.com   Ready     11m       v1.7.5+coreos.0
-node3.example.com   Ready     11m       v1.7.5+coreos.0
+node1.example.com   Ready     11m       v1.7.7+coreos.0
+node2.example.com   Ready     11m       v1.7.7+coreos.0
+node3.example.com   Ready     11m       v1.7.7+coreos.0
 
 $ kubectl get pods --all-namespaces
 NAMESPACE     NAME                                       READY     STATUS    RESTARTS   AGE

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@
     * [matchbox with Docker](Documentation/getting-started-docker.md)
 * Clusters
   * [etcd3](Documentation/getting-started-rkt.md) - Install a 3-node etcd3 cluster
-  * [Kubernetes](Documentation/bootkube.md) - Install a 3-node Kubernetes v1.7.5 cluster
+  * [Kubernetes](Documentation/bootkube.md) - Install a 3-node Kubernetes v1.7.7 cluster
 * Clusters (Terraform-based)
   * [etcd3](examples/terraform/etcd3-install/README.md) - Install a 3-node etcd3 cluster
-  * [Kubernetes](examples/terraform/bootkube-install/README.md) - Install a 3-node Kubernetes v1.7.5 cluster
+  * [Kubernetes](examples/terraform/bootkube-install/README.md) - Install a 3-node Kubernetes v1.7.7 cluster
 
 ### Projects
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ These examples use [Terraform](https://www.terraform.io/intro/) as a client to M
 |-------------------------------|-------------------------------|
 | [simple-install](terraform/simple-install) | Install Container Linux with an SSH key |
 | [etcd3-install](terraform/etcd3-install) | Install a 3-node etcd3 cluster |
-| [bootkube-install](terraform/bootkube-install) | Install a 3-node Kubernetes v1.7.5 cluster |
+| [bootkube-install](terraform/bootkube-install) | Install a 3-node Kubernetes v1.7.7 cluster |
 
 ### Customization
 
@@ -27,8 +27,8 @@ These examples mount raw Matchbox objects into a Matchbox server's `/var/lib/mat
 | grub | CoreOS Container Linux via GRUB2 Netboot | stable/1465.7.0 | RAM | NA |
 | etcd3 | PXE boot a 3-node etcd3 cluster with proxies | stable/1465.7.0 | RAM | None |
 | etcd3-install | Install a 3-node etcd3 cluster to disk | stable/1465.7.0 | Disk | None |
-| bootkube | PXE boot a 3-node Kubernetes v1.7.5 cluster | stable/1465.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
-| bootkube-install | Install a 3-node Kubernetes v1.7.5 cluster | stable/1465.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
+| bootkube | PXE boot a 3-node Kubernetes v1.7.7 cluster | stable/1465.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
+| bootkube-install | Install a 3-node Kubernetes v1.7.7 cluster | stable/1465.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
 
 ### Customization
 

--- a/examples/ignition/bootkube-controller.yaml
+++ b/examples/ignition/bootkube-controller.yaml
@@ -126,7 +126,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-          KUBELET_IMAGE_TAG=v1.7.5_coreos.0
+          KUBELET_IMAGE_TAG=v1.7.7_coreos.0
     - path: /etc/ssl/etcd/.empty
       filesystem: root
       mode: 0644
@@ -157,7 +157,7 @@ storage:
           # Wrapper for bootkube start
           set -e
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.6.2}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.7.0}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/opt/bootkube/assets}"
           exec /usr/bin/rkt run \
             --trust-keys-from-https \

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -95,7 +95,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-          KUBELET_IMAGE_TAG=v1.7.5_coreos.0
+          KUBELET_IMAGE_TAG=v1.7.7_coreos.0
     - path: /etc/ssl/etcd/.empty
       filesystem: root
       mode: 0644

--- a/examples/terraform/bootkube-install/README.md
+++ b/examples/terraform/bootkube-install/README.md
@@ -1,6 +1,6 @@
 # Kubernetes
 
-The Kubernetes example shows how to use Matchbox to network boot and provision a 3 node Kubernetes v1.7.5 cluster. This example uses [Terraform](https://www.terraform.io/intro/index.html) and a module provided by [Typhoon](https://github.com/poseidon/typhoon) to describe cluster resources. [kubernetes-incubator/bootkube](https://github.com/kubernetes-incubator/bootkube) is run once to bootstrap the Kubernetes control plane.
+The Kubernetes example shows how to use Matchbox to network boot and provision a 3 node Kubernetes v1.7.7 cluster. This example uses [Terraform](https://www.terraform.io/intro/index.html) and a module provided by [Typhoon](https://github.com/poseidon/typhoon) to describe cluster resources. [kubernetes-incubator/bootkube](https://github.com/kubernetes-incubator/bootkube) is run once to bootstrap the Kubernetes control plane.
 
 ## Requirements
 
@@ -129,9 +129,9 @@ $ sudo ./scripts/libvirt [start|reboot|shutdown|poweroff|destroy]
 $ export KUBECONFIG=assets/auth/kubeconfig
 $ kubectl get nodes
 NAME                STATUS    AGE       VERSION
-node1.example.com   Ready     11m       v1.7.5+coreos.0
-node2.example.com   Ready     11m       v1.7.5+coreos.0
-node3.example.com   Ready     11m       v1.7.5+coreos.0
+node1.example.com   Ready     11m       v1.7.7+coreos.0
+node2.example.com   Ready     11m       v1.7.7+coreos.0
+node3.example.com   Ready     11m       v1.7.7+coreos.0
 
 $ kubectl get pods --all-namespaces
 NAMESPACE     NAME                                       READY     STATUS    RESTARTS   AGE

--- a/examples/terraform/bootkube-install/cluster.tf
+++ b/examples/terraform/bootkube-install/cluster.tf
@@ -1,6 +1,6 @@
 // Kubernetes cluster
 module "cluster" {
-  source = "git::https://github.com/poseidon/typhoon//bare-metal/container-linux/kubernetes?ref=f7dd959e9c444ce1b2759a214b99990b89705ac4"
+  source = "git::https://github.com/poseidon/typhoon//bare-metal/container-linux/kubernetes?ref=1bc25c103654a497bcc0c2486104426f09ea2456"
 
   # install
   matchbox_http_endpoint  = "${var.matchbox_http_endpoint}"

--- a/examples/terraform/modules/README.md
+++ b/examples/terraform/modules/README.md
@@ -27,9 +27,6 @@ Available modules:
 |          | cached-container-linux-install | Install Container Linux to disk from matchbox assets cache |
 |          | etcd3    | Provision an etcd3 peer node |
 |          | etcd3-gateway | Provision an etcd3 gateway node |
-|          | bootkube-controller | Provision a self-hosted Kubernetes controller/master node |
-|          | bootkube-worker | Provisioner a self-hosted Kubernetes worker node |
-| bootkube |            | Creates a multi-controller, multi-worker self-hosted Kubernetes cluster |
 
 ## Customization
 

--- a/scripts/dev/get-bootkube
+++ b/scripts/dev/get-bootkube
@@ -4,7 +4,7 @@
 set -eu
 
 DEST=${1:-"bin"}
-VERSION="v0.6.2"
+VERSION="v0.7.0"
 
 URL="https://github.com/kubernetes-incubator/bootkube/releases/download/${VERSION}/bootkube.tar.gz"
 

--- a/scripts/dev/get-kubectl
+++ b/scripts/dev/get-kubectl
@@ -4,7 +4,7 @@
 set -eu
 
 DEST=${1:-"bin"}
-VERSION="v1.7.5"
+VERSION="v1.7.7"
 
 URL="https://storage.googleapis.com/kubernetes-release/release/${VERSION}/bin/linux/amd64/kubectl"
 

--- a/scripts/libvirt
+++ b/scripts/libvirt
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Manage VM nodes which have a specific set of hardware attributes.
 
-VM_MEMORY=${VM_MEMORY:-1024}
+VM_MEMORY=${VM_MEMORY:-1536}
 VM_DISK=${VM_DISK:-10}
 
 if [ "$EUID" -ne 0 ]


### PR DESCRIPTION
* Update from bootkube v0.6.2 to v0.7.0 ([release](https://github.com/kubernetes-incubator/bootkube/releases/tag/v0.7.0))
* Update kube-dns to fix dnsmasq vulnerability
* Update minimum required RAM from 1G to 1.5G