### PR TITLE
Update to Kubernetes v1.8.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Notable changes between releases.
 
 ### Examples / Modules
 
-* Upgrade Kubernetes example clusters to v1.8.1
+* Upgrade Kubernetes example clusters to v1.8.2
 * Kubernetes examples clusters enable etcd TLS
 * Deploy the Container Linux Update Operator (CLUO) to coordinate reboots of Container Linux nodes in Kubernetes clusters. See the cluster [addon docs](Documentation/cluster-addons.md).
 * Kubernetes examples (terraform and non-terraform) mask locksmithd

--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -1,6 +1,6 @@
 # Kubernetes
 
-The Kubernetes example provisions a 3 node Kubernetes v1.8.1 cluster. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run once on a controller node to bootstrap Kubernetes control plane components as pods before exiting. An etcd3 cluster across controllers is used to back Kubernetes.
+The Kubernetes example provisions a 3 node Kubernetes v1.8.2 cluster. [bootkube](https://github.com/kubernetes-incubator/bootkube) is run once on a controller node to bootstrap Kubernetes control plane components as pods before exiting. An etcd3 cluster across controllers is used to back Kubernetes.
 
 ## Requirements
 
@@ -11,11 +11,11 @@ Ensure that you've gone through the [matchbox with rkt](getting-started-rkt.md) 
 * Create the example libvirt client VMs
 * `/etc/hosts` entries for `node[1-3].example.com`
 
-Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.8.0 and add it on your $PATH.
+Install [bootkube](https://github.com/kubernetes-incubator/bootkube/releases) v0.8.1 and add it on your $PATH.
 
 ```sh
 $ bootkube version
-Version: v0.8.0
+Version: v0.8.1
 ```
 
 ## Examples
@@ -108,9 +108,9 @@ $ ssh core@node1.example.com 'journalctl -f -u bootkube'
 $ export KUBECONFIG=assets/auth/kubeconfig
 $ kubectl get nodes
 NAME                STATUS    AGE       VERSION
-node1.example.com   Ready     11m       v1.8.1+coreos.0
-node2.example.com   Ready     11m       v1.8.1+coreos.0
-node3.example.com   Ready     11m       v1.8.1+coreos.0
+node1.example.com   Ready     11m       v1.8.2
+node2.example.com   Ready     11m       v1.8.2
+node3.example.com   Ready     11m       v1.8.2
 
 $ kubectl get pods --all-namespaces
 NAMESPACE     NAME                                       READY     STATUS    RESTARTS   AGE

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@
   * [matchbox with rkt](Documentation/getting-started-rkt.md)
 * Clusters
   * [etcd3](Documentation/getting-started-rkt.md) - Install a 3-node etcd3 cluster
-  * [Kubernetes](Documentation/bootkube.md) - Install a 3-node Kubernetes v1.8.1 cluster
+  * [Kubernetes](Documentation/bootkube.md) - Install a 3-node Kubernetes v1.8.2 cluster
 * Clusters (Terraform-based)
   * [etcd3](examples/terraform/etcd3-install/README.md) - Install a 3-node etcd3 cluster
-  * [Kubernetes](examples/terraform/bootkube-install/README.md) - Install a 3-node Kubernetes v1.8.1 cluster
+  * [Kubernetes](examples/terraform/bootkube-install/README.md) - Install a 3-node Kubernetes v1.8.2 cluster
 
 ### Projects
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ These examples use [Terraform](https://www.terraform.io/intro/) as a client to M
 |-------------------------------|-------------------------------|
 | [simple-install](terraform/simple-install) | Install Container Linux with an SSH key |
 | [etcd3-install](terraform/etcd3-install) | Install a 3-node etcd3 cluster |
-| [bootkube-install](terraform/bootkube-install) | Install a 3-node Kubernetes v1.8.1 cluster |
+| [bootkube-install](terraform/bootkube-install) | Install a 3-node Kubernetes v1.8.2 cluster |
 
 ### Customization
 
@@ -27,8 +27,8 @@ These examples mount raw Matchbox objects into a Matchbox server's `/var/lib/mat
 | grub | CoreOS Container Linux via GRUB2 Netboot | stable/1465.7.0 | RAM | NA |
 | etcd3 | PXE boot a 3-node etcd3 cluster with proxies | stable/1465.7.0 | RAM | None |
 | etcd3-install | Install a 3-node etcd3 cluster to disk | stable/1465.7.0 | Disk | None |
-| bootkube | PXE boot a 3-node Kubernetes v1.8.1 cluster | stable/1465.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
-| bootkube-install | Install a 3-node Kubernetes v1.8.1 cluster | stable/1465.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
+| bootkube | PXE boot a 3-node Kubernetes v1.8.2 cluster | stable/1465.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
+| bootkube-install | Install a 3-node Kubernetes v1.8.2 cluster | stable/1465.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
 
 ### Customization
 

--- a/examples/ignition/bootkube-controller.yaml
+++ b/examples/ignition/bootkube-controller.yaml
@@ -64,7 +64,8 @@ systemd:
           --volume opt-cni-bin,kind=host,source=/opt/cni/bin \
           --mount volume=opt-cni-bin,target=/opt/cni/bin \
           --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log"
+          --mount volume=var-log,target=/var/log \
+          --insecure-options=image"
         ExecStartPre=/bin/mkdir -p /opt/cni/bin
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
@@ -125,8 +126,8 @@ storage:
       mode: 0644
       contents:
         inline: |
-          KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-          KUBELET_IMAGE_TAG=v1.8.1_coreos.0
+          KUBELET_IMAGE_URL=docker://gcr.io/google_containers/hyperkube
+          KUBELET_IMAGE_TAG=v1.8.1
     - path: /etc/ssl/etcd/.empty
       filesystem: root
       mode: 0644

--- a/examples/ignition/bootkube-controller.yaml
+++ b/examples/ignition/bootkube-controller.yaml
@@ -127,7 +127,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://gcr.io/google_containers/hyperkube
-          KUBELET_IMAGE_TAG=v1.8.1
+          KUBELET_IMAGE_TAG=v1.8.2
     - path: /etc/ssl/etcd/.empty
       filesystem: root
       mode: 0644
@@ -158,7 +158,7 @@ storage:
           # Wrapper for bootkube start
           set -e
           BOOTKUBE_ACI="${BOOTKUBE_ACI:-quay.io/coreos/bootkube}"
-          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.8.0}"
+          BOOTKUBE_VERSION="${BOOTKUBE_VERSION:-v0.8.1}"
           BOOTKUBE_ASSETS="${BOOTKUBE_ASSETS:-/opt/bootkube/assets}"
           exec /usr/bin/rkt run \
             --trust-keys-from-https \

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -41,7 +41,8 @@ systemd:
           --volume opt-cni-bin,kind=host,source=/opt/cni/bin \
           --mount volume=opt-cni-bin,target=/opt/cni/bin \
           --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log"
+          --mount volume=var-log,target=/var/log \
+          --insecure-options=image"
         ExecStartPre=/bin/mkdir -p /opt/cni/bin
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
@@ -94,8 +95,8 @@ storage:
       mode: 0644
       contents:
         inline: |
-          KUBELET_IMAGE_URL=quay.io/coreos/hyperkube
-          KUBELET_IMAGE_TAG=v1.8.1_coreos.0
+          KUBELET_IMAGE_URL=docker://gcr.io/google_containers/hyperkube
+          KUBELET_IMAGE_TAG=v1.8.1
     - path: /etc/ssl/etcd/.empty
       filesystem: root
       mode: 0644

--- a/examples/ignition/bootkube-worker.yaml
+++ b/examples/ignition/bootkube-worker.yaml
@@ -96,7 +96,7 @@ storage:
       contents:
         inline: |
           KUBELET_IMAGE_URL=docker://gcr.io/google_containers/hyperkube
-          KUBELET_IMAGE_TAG=v1.8.1
+          KUBELET_IMAGE_TAG=v1.8.2
     - path: /etc/ssl/etcd/.empty
       filesystem: root
       mode: 0644

--- a/examples/terraform/bootkube-install/README.md
+++ b/examples/terraform/bootkube-install/README.md
@@ -1,6 +1,6 @@
 # Kubernetes
 
-The Kubernetes example shows how to use Matchbox to network boot and provision a 3 node Kubernetes v1.8.1 cluster. This example uses [Terraform](https://www.terraform.io/intro/index.html) and a module provided by [Typhoon](https://github.com/poseidon/typhoon) to describe cluster resources. [kubernetes-incubator/bootkube](https://github.com/kubernetes-incubator/bootkube) is run once to bootstrap the Kubernetes control plane.
+The Kubernetes example shows how to use Matchbox to network boot and provision a 3 node Kubernetes v1.8.2 cluster. This example uses [Terraform](https://www.terraform.io/intro/index.html) and a module provided by [Typhoon](https://github.com/poseidon/typhoon) to describe cluster resources. [kubernetes-incubator/bootkube](https://github.com/kubernetes-incubator/bootkube) is run once to bootstrap the Kubernetes control plane.
 
 ## Requirements
 
@@ -129,9 +129,9 @@ $ sudo ./scripts/libvirt [start|reboot|shutdown|poweroff|destroy]
 $ export KUBECONFIG=assets/auth/kubeconfig
 $ kubectl get nodes
 NAME                STATUS    AGE       VERSION
-node1.example.com   Ready     11m       v1.8.1+coreos.0
-node2.example.com   Ready     11m       v1.8.1+coreos.0
-node3.example.com   Ready     11m       v1.8.1+coreos.0
+node1.example.com   Ready     11m       v1.8.2
+node2.example.com   Ready     11m       v1.8.2
+node3.example.com   Ready     11m       v1.8.2
 
 $ kubectl get pods --all-namespaces
 NAMESPACE     NAME                                       READY     STATUS    RESTARTS   AGE

--- a/examples/terraform/bootkube-install/cluster.tf
+++ b/examples/terraform/bootkube-install/cluster.tf
@@ -1,6 +1,6 @@
 // Kubernetes cluster
 module "cluster" {
-  source = "git::https://github.com/poseidon/typhoon//bare-metal/container-linux/kubernetes?ref=e4c479554cf31277431558556426dbb101be5694"
+  source = "git::https://github.com/poseidon/typhoon//bare-metal/container-linux/kubernetes?ref=60bc8957c924f45d898cff55a2a647ac21f11790"
 
   # install
   matchbox_http_endpoint  = "${var.matchbox_http_endpoint}"

--- a/scripts/dev/get-bootkube
+++ b/scripts/dev/get-bootkube
@@ -4,7 +4,7 @@
 set -eu
 
 DEST=${1:-"bin"}
-VERSION="v0.8.0"
+VERSION="v0.8.1"
 
 URL="https://github.com/kubernetes-incubator/bootkube/releases/download/${VERSION}/bootkube.tar.gz"
 


### PR DESCRIPTION
* Switch to the `gcr.io/google_containers/hyperkube:v1.8.2`
* Fixes a memory leak in the kube-apiserver v1.8.1

Relevant:
* https://github.com/kubernetes-incubator/bootkube/pull/750
* https://github.com/poseidon/typhoon/commit/60bc8957c924f45d898cff55a2a647ac21f11790