### PR TITLE
examples: Bump Container Linux to stable 1520.8.0

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -39,8 +39,8 @@ GET http://matchbox.foo/ipxe?label=value
 
 ```
 #!ipxe
-kernel /assets/coreos/1465.7.0/coreos_production_pxe.vmlinuz coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp} coreos.first_boot=1 coreos.autologin
-initrd  /assets/coreos/1465.7.0/coreos_production_pxe_image.cpio.gz
+kernel /assets/coreos/1520.8.0/coreos_production_pxe.vmlinuz coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp} coreos.first_boot=1 coreos.autologin
+initrd  /assets/coreos/1520.8.0/coreos_production_pxe_image.cpio.gz
 boot
 ```
 
@@ -67,9 +67,9 @@ default=0
 timeout=1
 menuentry "CoreOS" {
 echo "Loading kernel"
-linuxefi "(http;matchbox.foo:8080)/assets/coreos/1465.7.0/coreos_production_pxe.vmlinuz" "coreos.autologin" "coreos.config.url=http://matchbox.foo:8080/ignition" "coreos.first_boot"
+linuxefi "(http;matchbox.foo:8080)/assets/coreos/1520.8.0/coreos_production_pxe.vmlinuz" "coreos.autologin" "coreos.config.url=http://matchbox.foo:8080/ignition" "coreos.first_boot"
 echo "Loading initrd"
-initrdefi "(http;matchbox.foo:8080)/assets/coreos/1465.7.0/coreos_production_pxe_image.cpio.gz"
+initrdefi "(http;matchbox.foo:8080)/assets/coreos/1520.8.0/coreos_production_pxe_image.cpio.gz"
 }
 ```
 
@@ -231,7 +231,7 @@ If you need to serve static assets (e.g. kernel, initrd), `matchbox` can serve a
 ```
 matchbox.foo/assets/
 └── coreos
-    └── 1465.7.0
+    └── 1520.8.0
         ├── coreos_production_pxe.vmlinuz
         └── coreos_production_pxe_image.cpio.gz
     └── 1153.0.0

--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -30,7 +30,7 @@ The [examples](../examples) statically assign IP addresses to libvirt client VMs
 Download the CoreOS Container Linux image assets referenced in the target [profile](../examples/profiles).
 
 ```sh
-$ ./scripts/get-coreos stable 1465.7.0 ./examples/assets
+$ ./scripts/get-coreos stable 1520.8.0 ./examples/assets
 ```
 
 Add your SSH public key to each machine group definition [as shown](../examples/README.md#ssh-keys).

--- a/Documentation/deployment.md
+++ b/Documentation/deployment.md
@@ -218,7 +218,7 @@ Certificate chain
 Download a recent Container Linux [release](https://coreos.com/releases/) with signatures.
 
 ```sh
-$ ./scripts/get-coreos stable 1465.7.0 .     # note the "." 3rd argument
+$ ./scripts/get-coreos stable 1520.8.0 .     # note the "." 3rd argument
 ```
 
 Move the images to `/var/lib/matchbox/assets`,
@@ -230,7 +230,7 @@ $ sudo cp -r coreos /var/lib/matchbox/assets
 ```
 /var/lib/matchbox/assets/
 ├── coreos
-│   └── 1465.7.0
+│   └── 1520.8.0
 │       ├── CoreOS_Image_Signing_Key.asc
 │       ├── coreos_production_image.bin.bz2
 │       ├── coreos_production_image.bin.bz2.sig
@@ -243,7 +243,7 @@ $ sudo cp -r coreos /var/lib/matchbox/assets
 and verify the images are acessible.
 
 ```sh
-$ curl http://matchbox.example.com:8080/assets/coreos/1465.7.0/
+$ curl http://matchbox.example.com:8080/assets/coreos/1520.8.0/
 <pre>...
 ```
 

--- a/Documentation/getting-started-docker.md
+++ b/Documentation/getting-started-docker.md
@@ -28,7 +28,7 @@ $ cd matchbox
 Download CoreOS Container Linux image assets referenced by the `etcd3` [example](../examples) to `examples/assets`.
 
 ```sh
-$ ./scripts/get-coreos stable 1465.7.0 ./examples/assets
+$ ./scripts/get-coreos stable 1520.8.0 ./examples/assets
 ```
 
 For development convenience, add `/etc/hosts` entries for nodes so they may be referenced by name.

--- a/Documentation/getting-started-rkt.md
+++ b/Documentation/getting-started-rkt.md
@@ -30,7 +30,7 @@ $ cd matchbox
 Download CoreOS Container Linux image assets referenced by the `etcd3` [example](../examples) to `examples/assets`.
 
 ```sh
-$ ./scripts/get-coreos stable 1465.7.0 ./examples/assets
+$ ./scripts/get-coreos stable 1520.8.0 ./examples/assets
 ```
 
 ## Network

--- a/Documentation/matchbox.md
+++ b/Documentation/matchbox.md
@@ -64,8 +64,8 @@ Profiles reference an Ignition config, Cloud-Config, and/or generic config by na
   "ignition_id": "etcd.yaml",
   "generic_id": "some-service.cfg",
   "boot": {
-    "kernel": "/assets/coreos/1465.7.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1465.7.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1520.8.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1520.8.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,13 +22,13 @@ These examples mount raw Matchbox objects into a Matchbox server's `/var/lib/mat
 
 | Name       | Description | CoreOS Container Linux Version | FS | Docs | 
 |------------|-------------|----------------|----|-----------|
-| simple | CoreOS Container Linux with autologin, using iPXE | stable/1465.7.0 | RAM | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
-| simple-install | CoreOS Container Linux Install, using iPXE | stable/1465.7.0 | RAM | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
-| grub | CoreOS Container Linux via GRUB2 Netboot | stable/1465.7.0 | RAM | NA |
-| etcd3 | PXE boot a 3-node etcd3 cluster with proxies | stable/1465.7.0 | RAM | None |
-| etcd3-install | Install a 3-node etcd3 cluster to disk | stable/1465.7.0 | Disk | None |
-| bootkube | PXE boot a 3-node Kubernetes v1.8.2 cluster | stable/1465.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
-| bootkube-install | Install a 3-node Kubernetes v1.8.2 cluster | stable/1465.7.0 | Disk | [tutorial](../Documentation/bootkube.md) |
+| simple | CoreOS Container Linux with autologin, using iPXE | stable/1520.8.0 | RAM | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
+| simple-install | CoreOS Container Linux Install, using iPXE | stable/1520.8.0 | RAM | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
+| grub | CoreOS Container Linux via GRUB2 Netboot | stable/1520.8.0 | RAM | NA |
+| etcd3 | PXE boot a 3-node etcd3 cluster with proxies | stable/1520.8.0 | RAM | None |
+| etcd3-install | Install a 3-node etcd3 cluster to disk | stable/1520.8.0 | Disk | None |
+| bootkube | PXE boot a 3-node Kubernetes v1.8.2 cluster | stable/1520.8.0 | Disk | [tutorial](../Documentation/bootkube.md) |
+| bootkube-install | Install a 3-node Kubernetes v1.8.2 cluster | stable/1520.8.0 | Disk | [tutorial](../Documentation/bootkube.md) |
 
 ### Customization
 

--- a/examples/groups/bootkube-install/install.json
+++ b/examples/groups/bootkube-install/install.json
@@ -4,7 +4,7 @@
   "profile": "install-reboot",
   "metadata": {
     "coreos_channel": "stable",
-    "coreos_version": "1465.7.0",
+    "coreos_version": "1520.8.0",
     "ignition_endpoint": "http://matchbox.foo:8080/ignition",
     "baseurl": "http://matchbox.foo:8080/assets/coreos"
   }

--- a/examples/groups/etcd3-install/install.json
+++ b/examples/groups/etcd3-install/install.json
@@ -4,7 +4,7 @@
   "profile": "install-reboot",
   "metadata": {
     "coreos_channel": "stable",
-    "coreos_version": "1465.7.0",
+    "coreos_version": "1520.8.0",
     "ignition_endpoint": "http://matchbox.foo:8080/ignition",
     "baseurl": "http://matchbox.foo:8080/assets/coreos"
   }

--- a/examples/groups/simple-install/install.json
+++ b/examples/groups/simple-install/install.json
@@ -4,7 +4,7 @@
   "profile": "simple-install",
   "metadata": {
     "coreos_channel": "stable",
-    "coreos_version": "1465.7.0",
+    "coreos_version": "1520.8.0",
     "ignition_endpoint": "http://matchbox.foo:8080/ignition",
     "baseurl": "http://matchbox.foo:8080/assets/coreos"
   }

--- a/examples/profiles/bootkube-controller.json
+++ b/examples/profiles/bootkube-controller.json
@@ -2,8 +2,8 @@
   "id": "bootkube-controller",
   "name": "bootkube Ready Controller",
   "boot": {
-    "kernel": "/assets/coreos/1465.7.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1465.7.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1520.8.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1520.8.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "root=/dev/sda1",
       "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",

--- a/examples/profiles/bootkube-worker.json
+++ b/examples/profiles/bootkube-worker.json
@@ -2,8 +2,8 @@
   "id": "bootkube-worker",
   "name": "bootkube Ready Worker",
   "boot": {
-    "kernel": "/assets/coreos/1465.7.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1465.7.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1520.8.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1520.8.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "root=/dev/sda1",
       "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",

--- a/examples/profiles/etcd3-gateway.json
+++ b/examples/profiles/etcd3-gateway.json
@@ -2,8 +2,8 @@
   "id": "etcd3-gateway",
   "name": "etcd3-gateway",
   "boot": {
-    "kernel": "/assets/coreos/1465.7.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1465.7.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1520.8.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1520.8.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",

--- a/examples/profiles/etcd3.json
+++ b/examples/profiles/etcd3.json
@@ -2,8 +2,8 @@
   "id": "etcd3",
   "name": "etcd3",
   "boot": {
-    "kernel": "/assets/coreos/1465.7.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1465.7.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1520.8.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1520.8.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",

--- a/examples/profiles/grub.json
+++ b/examples/profiles/grub.json
@@ -2,8 +2,8 @@
   "id": "grub",
   "name": "CoreOS Container Linux via GRUB2",
   "boot": {
-    "kernel": "(http;matchbox.foo:8080)/assets/coreos/1465.7.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["(http;matchbox.foo:8080)/assets/coreos/1465.7.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "(http;matchbox.foo:8080)/assets/coreos/1520.8.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["(http;matchbox.foo:8080)/assets/coreos/1520.8.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "coreos.config.url=http://matchbox.foo:8080/ignition",
       "coreos.first_boot=yes",

--- a/examples/profiles/install-reboot.json
+++ b/examples/profiles/install-reboot.json
@@ -2,8 +2,8 @@
   "id": "install-reboot",
   "name": "Install CoreOS Container Linux and Reboot",
   "boot": {
-    "kernel": "/assets/coreos/1465.7.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1465.7.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1520.8.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1520.8.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",

--- a/examples/profiles/simple-install.json
+++ b/examples/profiles/simple-install.json
@@ -2,8 +2,8 @@
   "id": "simple-install",
   "name": "Simple CoreOS Container Linux Alpha Install",
   "boot": {
-    "kernel": "/assets/coreos/1465.7.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1465.7.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1520.8.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1520.8.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",

--- a/examples/profiles/simple.json
+++ b/examples/profiles/simple.json
@@ -2,8 +2,8 @@
 	"id": "simple",
 	"name": "Simple CoreOS Container Linux Alpha",
 	"boot": {
-		"kernel": "/assets/coreos/1465.7.0/coreos_production_pxe.vmlinuz",
-		"initrd": ["/assets/coreos/1465.7.0/coreos_production_pxe_image.cpio.gz"],
+		"kernel": "/assets/coreos/1520.8.0/coreos_production_pxe.vmlinuz",
+		"initrd": ["/assets/coreos/1520.8.0/coreos_production_pxe_image.cpio.gz"],
 		"args": [
 			"coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
 			"coreos.first_boot=yes",

--- a/examples/terraform/bootkube-install/README.md
+++ b/examples/terraform/bootkube-install/README.md
@@ -35,7 +35,7 @@ matchbox_rpc_endpoint = "matchbox.example.com:8081"
 ssh_authorized_key = "ADD ME"
 
 cluster_name = "demo"
-container_linux_version = "1465.7.0"
+container_linux_version = "1520.8.0"
 container_linux_channel = "stable"
 ```
 

--- a/examples/terraform/bootkube-install/cluster.tf
+++ b/examples/terraform/bootkube-install/cluster.tf
@@ -1,6 +1,6 @@
 // Kubernetes cluster
 module "cluster" {
-  source = "git::https://github.com/poseidon/typhoon//bare-metal/container-linux/kubernetes?ref=60bc8957c924f45d898cff55a2a647ac21f11790"
+  source = "git::https://github.com/poseidon/typhoon//bare-metal/container-linux/kubernetes?ref=34ec7e98621208757b3c860cc9ce7add6922d56c"
 
   # install
   matchbox_http_endpoint  = "${var.matchbox_http_endpoint}"

--- a/examples/terraform/bootkube-install/multi-controller.tfvars.example
+++ b/examples/terraform/bootkube-install/multi-controller.tfvars.example
@@ -3,7 +3,7 @@ matchbox_rpc_endpoint = "matchbox.example.com:8081"
 # ssh_authorized_key = "ADD ME"
 
 cluster_name = "example"
-container_linux_version = "1465.7.0"
+container_linux_version = "1520.8.0"
 container_linux_channel = "stable"
 
 # Machines

--- a/examples/terraform/bootkube-install/terraform.tfvars.example
+++ b/examples/terraform/bootkube-install/terraform.tfvars.example
@@ -3,7 +3,7 @@ matchbox_rpc_endpoint = "matchbox.example.com:8081"
 # ssh_authorized_key = "ADD ME"
 
 cluster_name = "example"
-container_linux_version = "1465.7.0"
+container_linux_version = "1520.8.0"
 container_linux_channel = "stable"
 
 # Machines

--- a/examples/terraform/etcd3-install/etcd3.tf
+++ b/examples/terraform/etcd3-install/etcd3.tf
@@ -2,7 +2,7 @@
 module "profiles" {
   source                  = "../modules/profiles"
   matchbox_http_endpoint  = "${var.matchbox_http_endpoint}"
-  container_linux_version = "1465.7.0"
+  container_linux_version = "1520.8.0"
   container_linux_channel = "stable"
   install_disk            = "${var.install_disk}"
   container_linux_oem     = "${var.container_linux_oem}"

--- a/scripts/devnet
+++ b/scripts/devnet
@@ -15,7 +15,7 @@ ASSETS_DIR="${ASSETS_DIR:-$PWD/examples/assets}"
 CONFIG_DIR="${CONFIG_DIR:-$PWD/examples/etc/matchbox}"
 
 COREOS_CHANNEL=stable
-COREOS_VERSION=1465.7.0
+COREOS_VERSION=1520.8.0
 MATCHBOX_ARGS=""
 
 if [ "$EUID" -ne 0 ]

--- a/scripts/get-coreos
+++ b/scripts/get-coreos
@@ -9,7 +9,7 @@ set -eou pipefail
 GPG=${GPG:-/usr/bin/gpg}
 
 CHANNEL=${1:-"stable"}
-VERSION=${2:-"1465.7.0"}
+VERSION=${2:-"1520.8.0"}
 DEST_DIR=${3:-"$PWD/examples/assets"}
 OEM_ID=${OEM_ID:-""}
 DEST=$DEST_DIR/coreos/$VERSION

--- a/scripts/libvirt
+++ b/scripts/libvirt
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Manage VM nodes which have a specific set of hardware attributes.
 
-VM_MEMORY=${VM_MEMORY:-1536}
+VM_MEMORY=${VM_MEMORY:-2048}
 VM_DISK=${VM_DISK:-10}
 
 if [ "$EUID" -ne 0 ]

--- a/tests/smoke/bootkube.tfvars
+++ b/tests/smoke/bootkube.tfvars
@@ -3,7 +3,7 @@ matchbox_rpc_endpoint = "matchbox.example.com:8081"
 ssh_authorized_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDPQFdwVLr+alsWIgYRz9OdqDhnx9jjuFbkdSdpqq4gd9uZApYlivMDD4UgjFazQpezx8DiNhu9ym7i6LgAcdwi+10hE4L9yoJv9uBgbBxOAd65znqLqF91NtV4mlKP5YfJtR7Ehs+pTB+IIC+o5veDbPn+BYgDMJ2x7Osbn1/gFSDken/yoOFbYbRMGMfVEQYjJzC4r/qCKH0bl/xuVNLxf9FkWSTCcQFKGOndwuGITDkshD4r2Kk8gUddXPxoahBv33/2QH0CY5zbKYjhgN6I6WtwO+O1uJwtNeV1AGhYjurdd60qggNwx+W7623uK3nIXvJd3hzDO8u5oa53/tIL fake-test-key"
 
 cluster_name = "example"
-container_linux_version = "1465.7.0"
+container_linux_version = "1520.8.0"
 container_linux_channel = "stable"
 
 # Machines


### PR DESCRIPTION
* Increase minimum RAM required to use PXE image
* https://coreos.com/releases/#1520.5.0