### PR TITLE
travis.yml: Fix travis to publish master images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ deploy:
   skip_cleanup: true
   on:
     branch: master
-    go: '1.8.3'
+    go: '1.8.x'
 notifications:
   email: change


### PR DESCRIPTION
Travis CI is supposed to auto-publish images from master with the SHA tag to compliment official releases. In #647, the build and deploy matrix stopped matching so publishing stopped. This should fix.