### PR TITLE
travis.yml: Ensure deploy condition matches build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ services:
 go:
   - 1.7.x
   - 1.8.x
+  - 1.8.5
   - 1.9.x
   - tip
 matrix:
@@ -20,6 +21,6 @@ deploy:
   skip_cleanup: true
   on:
     branch: master
-    go: '1.8.x'
+    go: '1.8.5'
 notifications:
   email: change

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Notable changes between releases.
 * Update Container Linux config transpiler to v0.5.0
 * Update Ignition to v0.19.0, render v2.1.0 Ignition configs
 * Drop support for Container Linux versions below 1465.0.0 (breaking)
+* Build Matchbox with Go 1.8.5 for images and binaries
 * Remove Profile `Cmdline` map (deprecated in v0.5.0), use `Args` slice instead
 * Remove pixiecore support (deprecated in v0.5.0)
 * Remove `ContextHandler`, `ContextHandlerFunc`, and `NewHandler` from the `matchbox/http` package.


### PR DESCRIPTION
* Build binaries for Docker images with Go 1.8.5
* Travis hasn't been publishing quay.io images since #647
* Travis should "deploy" publish the quay image for Go 1.8.5

rel #647 #671