### PR TITLE
contrib/dnsmasq: Add ipxe.efi for dnsmasq:v0.5.0

### DIFF
--- a/contrib/dnsmasq/Makefile
+++ b/contrib/dnsmasq/Makefile
@@ -1,4 +1,4 @@
-VERSION=v0.4.1
+VERSION=v0.5.0
 
 IMAGE_REPO=coreos/dnsmasq
 QUAY_REPO=quay.io/coreos/dnsmasq
@@ -6,12 +6,12 @@ QUAY_REPO=quay.io/coreos/dnsmasq
 .PHONY: all
 all: docker-image
 
-.PHONY: undionly
-undionly:
+.PHONY: tftp
+tftp:
 	@./get-tftp-files
 
 .PHONY: docker-image
-docker-image: undionly
+docker-image: tftp
 	@sudo docker build --rm=true -t $(IMAGE_REPO):$(VERSION) .
 	@sudo docker tag $(IMAGE_REPO):$(VERSION) $(IMAGE_REPO):latest
 

--- a/contrib/dnsmasq/README.md
+++ b/contrib/dnsmasq/README.md
@@ -2,7 +2,7 @@
 
 `dnsmasq` provides a container image for running DHCP, proxy DHCP, DNS, and/or TFTP with [dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html). Use it to test different network setups with clusters of network bootable machines.
 
-The image bundles `undionly.kpxe` which chainloads PXE clients to iPXE and `grub.efi` (experimental) which chainloads UEFI architectures to GRUB2.
+The image bundles `undionly.kpxe`, `ipxe.efi`, and `grub.efi` (experimental) for chainloading BIOS and UEFI clients to iPXE.
 
 ## Usage
 
@@ -15,8 +15,15 @@ sudo rkt run --net=host quay.io/coreos/dnsmasq \
   --dhcp-range=192.168.1.3,192.168.1.254 \
   --enable-tftp \
   --tftp-root=/var/lib/tftpboot \
+  --dhcp-match=set:bios,option:client-arch,0 \
+  --dhcp-boot=tag:bios,undionly.kpxe \
+  --dhcp-match=set:efi32,option:client-arch,6 \
+  --dhcp-boot=tag:efi32,ipxe.efi \
+  --dhcp-match=set:efibc,option:client-arch,7 \
+  --dhcp-boot=tag:efibc,ipxe.efi \
+  --dhcp-match=set:efi64,option:client-arch,9 \
+  --dhcp-boot=tag:efi64,ipxe.efi \
   --dhcp-userclass=set:ipxe,iPXE \
-  --dhcp-boot=tag:#ipxe,undionly.kpxe \
   --dhcp-boot=tag:ipxe,http://matchbox.example.com:8080/boot.ipxe \
   --address=/matchbox.example.com/192.168.1.2 \
   --log-queries \
@@ -28,8 +35,15 @@ sudo docker run --rm --cap-add=NET_ADMIN --net=host quay.io/coreos/dnsmasq \
   -d -q \
   --dhcp-range=192.168.1.3,192.168.1.254 \
   --enable-tftp --tftp-root=/var/lib/tftpboot \
+  --dhcp-match=set:bios,option:client-arch,0 \
+  --dhcp-boot=tag:bios,undionly.kpxe \
+  --dhcp-match=set:efi32,option:client-arch,6 \
+  --dhcp-boot=tag:efi32,ipxe.efi \
+  --dhcp-match=set:efibc,option:client-arch,7 \
+  --dhcp-boot=tag:efibc,ipxe.efi \
+  --dhcp-match=set:efi64,option:client-arch,9 \
+  --dhcp-boot=tag:efi64,ipxe.efi \
   --dhcp-userclass=set:ipxe,iPXE \
-  --dhcp-boot=tag:#ipxe,undionly.kpxe \
   --dhcp-boot=tag:ipxe,http://matchbox.example.com:8080/boot.ipxe \
   --address=/matchbox.example/192.168.1.2 \
   --log-queries \
@@ -53,8 +67,13 @@ Configuration arguments can be provided as flags. Check the dnsmasq [man pages](
 
 Build a container image locally.
 
-    make docker-image
+```
+make docker-image
+```
 
 Run the image with Docker on the `docker0` bridge (default).
 
-    sudo docker run --rm --cap-add=NET_ADMIN coreos/dnsmasq -d -q
+```
+sudo docker run --rm --cap-add=NET_ADMIN coreos/dnsmasq -d -q
+```
+

--- a/contrib/dnsmasq/docker0.conf
+++ b/contrib/dnsmasq/docker0.conf
@@ -11,8 +11,22 @@ dhcp-host=52:54:00:d7:99:c7,172.17.0.24,1h
 enable-tftp
 tftp-root=/var/lib/tftpboot
 
+# Legacy PXE
+dhcp-match=set:bios,option:client-arch,0
+dhcp-boot=tag:bios,undionly.kpxe
+
+# UEFI
+dhcp-match=set:efi32,option:client-arch,6
+dhcp-boot=tag:efi32,ipxe.efi
+
+dhcp-match=set:efibc,option:client-arch,7
+dhcp-boot=tag:efibc,ipxe.efi
+
+dhcp-match=set:efi64,option:client-arch,9
+dhcp-boot=tag:efi64,ipxe.efi
+
+# iPXE
 dhcp-userclass=set:ipxe,iPXE
-dhcp-boot=tag:#ipxe,undionly.kpxe
 dhcp-boot=tag:ipxe,http://matchbox.foo:8080/boot.ipxe
 
 log-queries

--- a/contrib/dnsmasq/docker0.conf
+++ b/contrib/dnsmasq/docker0.conf
@@ -27,13 +27,11 @@ dhcp-boot=tag:efi64,ipxe.efi
 
 # iPXE
 dhcp-userclass=set:ipxe,iPXE
-dhcp-boot=tag:ipxe,http://matchbox.foo:8080/boot.ipxe
+dhcp-boot=tag:ipxe,http://matchbox.example.com:8080/boot.ipxe
 
 log-queries
 log-dhcp
 
-address=/bootcfg.foo/172.18.0.2
-address=/matchbox.foo/172.17.0.2
 address=/matchbox.example.com/172.17.0.2
 address=/node1.example.com/172.17.0.21
 address=/node2.example.com/172.17.0.22

--- a/contrib/dnsmasq/get-tftp-files
+++ b/contrib/dnsmasq/get-tftp-files
@@ -10,6 +10,7 @@ fi
 
 curl -s -o $DEST/undionly.kpxe http://boot.ipxe.org/undionly.kpxe
 cp $DEST/undionly.kpxe $DEST/undionly.kpxe.0
+curl -s -o $DEST/ipxe.efi http://boot.ipxe.org/ipxe.efi
 
 # Any vaguely recent CoreOS grub.efi is fine
 curl -s -o $DEST/grub.efi https://stable.release.core-os.net/amd64-usr/1353.7.0/coreos_production_pxe_grub.efi

--- a/contrib/dnsmasq/metal0.conf
+++ b/contrib/dnsmasq/metal0.conf
@@ -13,13 +13,11 @@ tftp-root=/var/lib/tftpboot
 
 dhcp-userclass=set:ipxe,iPXE
 dhcp-boot=tag:#ipxe,undionly.kpxe
-dhcp-boot=tag:ipxe,http://matchbox.foo:8080/boot.ipxe
+dhcp-boot=tag:ipxe,http://matchbox.example.com:8080/boot.ipxe
 
 log-queries
 log-dhcp
 
-address=/bootcfg.foo/172.18.0.2
-address=/matchbox.foo/172.18.0.2
 address=/matchbox.example.com/172.18.0.2
 address=/node1.example.com/172.18.0.21
 address=/node2.example.com/172.18.0.22

--- a/examples/profiles/bootkube-controller.json
+++ b/examples/profiles/bootkube-controller.json
@@ -5,6 +5,7 @@
     "kernel": "/assets/coreos/1520.8.0/coreos_production_pxe.vmlinuz",
     "initrd": ["/assets/coreos/1520.8.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
+      "initrd=coreos_production_pxe_image.cpio.gz",
       "root=/dev/sda1",
       "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",

--- a/examples/profiles/bootkube-worker.json
+++ b/examples/profiles/bootkube-worker.json
@@ -5,6 +5,7 @@
     "kernel": "/assets/coreos/1520.8.0/coreos_production_pxe.vmlinuz",
     "initrd": ["/assets/coreos/1520.8.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
+      "initrd=coreos_production_pxe_image.cpio.gz",
       "root=/dev/sda1",
       "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",

--- a/examples/profiles/etcd3-gateway.json
+++ b/examples/profiles/etcd3-gateway.json
@@ -5,6 +5,7 @@
     "kernel": "/assets/coreos/1520.8.0/coreos_production_pxe.vmlinuz",
     "initrd": ["/assets/coreos/1520.8.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
+      "initrd=coreos_production_pxe_image.cpio.gz",
       "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",
       "console=tty0",

--- a/examples/profiles/etcd3.json
+++ b/examples/profiles/etcd3.json
@@ -5,6 +5,7 @@
     "kernel": "/assets/coreos/1520.8.0/coreos_production_pxe.vmlinuz",
     "initrd": ["/assets/coreos/1520.8.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
+      "initrd=coreos_production_pxe_image.cpio.gz",
       "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",
       "console=tty0",

--- a/examples/profiles/install-reboot.json
+++ b/examples/profiles/install-reboot.json
@@ -5,6 +5,7 @@
     "kernel": "/assets/coreos/1520.8.0/coreos_production_pxe.vmlinuz",
     "initrd": ["/assets/coreos/1520.8.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
+      "initrd=coreos_production_pxe_image.cpio.gz",
       "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",
       "console=tty0",

--- a/examples/profiles/simple-install.json
+++ b/examples/profiles/simple-install.json
@@ -5,6 +5,7 @@
     "kernel": "/assets/coreos/1520.8.0/coreos_production_pxe.vmlinuz",
     "initrd": ["/assets/coreos/1520.8.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
+      "initrd=coreos_production_pxe_image.cpio.gz",
       "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",
       "console=tty0",

--- a/examples/profiles/simple.json
+++ b/examples/profiles/simple.json
@@ -1,16 +1,19 @@
 {
-	"id": "simple",
-	"name": "Simple CoreOS Container Linux Alpha",
-	"boot": {
-		"kernel": "/assets/coreos/1520.8.0/coreos_production_pxe.vmlinuz",
-		"initrd": ["/assets/coreos/1520.8.0/coreos_production_pxe_image.cpio.gz"],
-		"args": [
-			"coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
-			"coreos.first_boot=yes",
-			"console=tty0",
-			"console=ttyS0",
-			"coreos.autologin"
-		]
-	},
-	"ignition_id": "ssh.yaml"
+  "id": "simple",
+  "name": "Simple CoreOS Container Linux Alpha",
+  "boot": {
+    "kernel": "/assets/coreos/1520.8.0/coreos_production_pxe.vmlinuz",
+    "initrd": [
+      "/assets/coreos/1520.8.0/coreos_production_pxe_image.cpio.gz"
+    ],
+    "args": [
+      "initrd=coreos_production_pxe_image.cpio.gz",
+      "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
+      "coreos.first_boot=yes",
+      "console=tty0",
+      "console=ttyS0",
+      "coreos.autologin"
+    ]
+  },
+  "ignition_id": "ssh.yaml"
 }

--- a/examples/terraform/bootkube-install/cluster.tf
+++ b/examples/terraform/bootkube-install/cluster.tf
@@ -1,6 +1,6 @@
 // Kubernetes cluster
 module "cluster" {
-  source = "git::https://github.com/poseidon/typhoon//bare-metal/container-linux/kubernetes?ref=d774c51297a73d06d80de6bc4447a6eaebc49671"
+  source = "git::https://github.com/poseidon/typhoon//bare-metal/container-linux/kubernetes?ref=07d257aa7bcfba1ced569308ae64183def9efe81"
 
   # install
   matchbox_http_endpoint  = "${var.matchbox_http_endpoint}"

--- a/examples/terraform/modules/profiles/profiles.tf
+++ b/examples/terraform/modules/profiles/profiles.tf
@@ -8,6 +8,7 @@ resource "matchbox_profile" "container-linux-install" {
   ]
 
   args = [
+    "initrd=coreos_production_pxe_image.cpio.gz",
     "coreos.config.url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
     "coreos.first_boot=yes",
     "console=tty0",
@@ -43,6 +44,7 @@ resource "matchbox_profile" "cached-container-linux-install" {
   ]
 
   args = [
+    "initrd=coreos_production_pxe_image.cpio.gz",
     "coreos.config.url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
     "coreos.first_boot=yes",
     "console=tty0",

--- a/examples/terraform/simple-install/profiles.tf
+++ b/examples/terraform/simple-install/profiles.tf
@@ -8,6 +8,7 @@ resource "matchbox_profile" "coreos-install" {
   ]
 
   args = [
+    "initrd=coreos_production_pxe_image.cpio.gz",
     "coreos.config.url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
     "coreos.first_boot=yes",
     "console=tty0",

--- a/scripts/devnet
+++ b/scripts/devnet
@@ -129,7 +129,7 @@ function rkt_create {
     --dns=host \
     --mount volume=config,target=/etc/dnsmasq.conf \
     --volume config,kind=host,source=$DIR/../contrib/dnsmasq/metal0.conf \
-    quay.io/coreos/dnsmasq:v0.4.1 \
+    quay.io/coreos/dnsmasq:v0.5.0 \
     --caps-retain="CAP_NET_ADMIN,CAP_NET_BIND_SERVICE"
 
   status
@@ -181,7 +181,7 @@ function docker_create {
     -d \
     --cap-add=NET_ADMIN \
     -v $PWD/contrib/dnsmasq/docker0.conf:/etc/dnsmasq.conf:Z \
-    quay.io/coreos/dnsmasq:v0.4.1 -d
+    quay.io/coreos/dnsmasq:v0.5.0 -d
 }
 
 function docker_status {

--- a/scripts/libvirt
+++ b/scripts/libvirt
@@ -70,10 +70,10 @@ function create_rkt {
 }
 
 function create_uefi {
-  virt-install --name $NODE1_NAME --network=bridge=docker0,model=e1000,mac=$NODE1_MAC $COMMON_VIRT_OPTS --boot=uefi,network
-  virt-install --name $NODE2_NAME --network=bridge=docker0,model=e1000,mac=$NODE2_MAC $COMMON_VIRT_OPTS --boot=uefi,network
-  virt-install --name $NODE3_NAME --network=bridge=docker0,model=e1000,mac=$NODE3_MAC $COMMON_VIRT_OPTS --boot=uefi,network
-  virt-install --name $NODE4_NAME --network=bridge=docker0,model=e1000,mac=$NODE4_MAC $COMMON_VIRT_OPTS --boot=uefi,network
+  virt-install --name $NODE1_NAME --network=bridge=docker0,model=e1000,mac=$NODE1_MAC $COMMON_VIRT_OPTS --boot=hd,uefi,network
+  virt-install --name $NODE2_NAME --network=bridge=docker0,model=e1000,mac=$NODE2_MAC $COMMON_VIRT_OPTS --boot=hd,uefi,network
+  virt-install --name $NODE3_NAME --network=bridge=docker0,model=e1000,mac=$NODE3_MAC $COMMON_VIRT_OPTS --boot=hd,uefi,network
+  virt-install --name $NODE4_NAME --network=bridge=docker0,model=e1000,mac=$NODE4_MAC $COMMON_VIRT_OPTS --boot=hd,uefi,network
 }
 
 nodes=(node1 node2 node3 node4)

--- a/scripts/libvirt
+++ b/scripts/libvirt
@@ -33,7 +33,7 @@ function usage {
   echo -e "\tcreate\t\tcreate QEMU/KVM nodes on a rkt CNI metal0 bridge"
   echo -e "\tcreate-rkt\tcreate QEMU/KVM nodes on a rkt CNI metal0 bridge"
   echo -e "\tcreate-docker\tcreate QEMU/KVM nodes on the docker0 bridge"
-  echo -e "\tcreate-uefi\tcreate UEFI QEMU/KVM nodes on the rkt CNI metal0 bridge"
+  echo -e "\tcreate-uefi\tcreate UEFI QEMU/KVM nodes on the docker0 bridge"
   echo -e "\tstart\t\tstart the QEMU/KVM nodes"
   echo -e "\treboot\t\treboot the QEMU/KVM nodes"
   echo -e "\tshutdown\tshutdown the QEMU/KVM nodes"
@@ -70,10 +70,10 @@ function create_rkt {
 }
 
 function create_uefi {
-  virt-install --name $NODE1_NAME --network=bridge=metal0,model=e1000,mac=$NODE1_MAC $COMMON_VIRT_OPTS --boot=uefi,network
-  virt-install --name $NODE2_NAME --network=bridge=metal0,model=e1000,mac=$NODE2_MAC $COMMON_VIRT_OPTS --boot=uefi,network
-  virt-install --name $NODE3_NAME --network=bridge=metal0,model=e1000,mac=$NODE3_MAC $COMMON_VIRT_OPTS --boot=uefi,network
-  virt-install --name $NODE4_NAME --network=bridge=metal0,model=e1000,mac=$NODE4_MAC $COMMON_VIRT_OPTS --boot=uefi,network
+  virt-install --name $NODE1_NAME --network=bridge=docker0,model=e1000,mac=$NODE1_MAC $COMMON_VIRT_OPTS --boot=uefi,network
+  virt-install --name $NODE2_NAME --network=bridge=docker0,model=e1000,mac=$NODE2_MAC $COMMON_VIRT_OPTS --boot=uefi,network
+  virt-install --name $NODE3_NAME --network=bridge=docker0,model=e1000,mac=$NODE3_MAC $COMMON_VIRT_OPTS --boot=uefi,network
+  virt-install --name $NODE4_NAME --network=bridge=docker0,model=e1000,mac=$NODE4_MAC $COMMON_VIRT_OPTS --boot=uefi,network
 }
 
 nodes=(node1 node2 node3 node4)


### PR DESCRIPTION
* Add ipxe.efi to dnsmasq image's`/var/lib/tftpboot` directory
* Build `quay.io/coreos/dnsmasq:v0.5.0` Docker image
* Add initrd kernel argument respected only by UEFI https://github.com/coreos/bugs/issues/1239
* Improve network-setup docs and scripts to cover UEFI clients and to support launching UEFI QEMU/KVM clusters locally
* Ensure `./libvirt create-uefi` is usable with cluster examples
* Reduce references to grub.efi flow, its not a happy path

rel: https://github.com/coreos/bugs/issues/1239