### PR TITLE
fix loading multiple initrds

### DIFF
--- a/matchbox/http/ipxe.go
+++ b/matchbox/http/ipxe.go
@@ -15,7 +15,9 @@ chain ipxe?uuid=${uuid}&mac=${mac:hexhyp}&domain=${domain}&hostname=${hostname}&
 
 var ipxeTemplate = template.Must(template.New("iPXE config").Parse(`#!ipxe
 kernel {{.Kernel}}{{range $arg := .Args}} {{$arg}}{{end}}
-initrd {{ range $element := .Initrd }}{{$element}} {{end}}
+{{- range $element := .Initrd }}
+initrd {{$element}}
+{{- end}}
 boot
 `))
 

--- a/matchbox/http/ipxe_test.go
+++ b/matchbox/http/ipxe_test.go
@@ -34,7 +34,8 @@ func TestIPXEHandler(t *testing.T) {
 	// - the Profile's NetBoot config is rendered as an iPXE script
 	expectedScript := `#!ipxe
 kernel /image/kernel a=b c
-initrd /image/initrd_a /image/initrd_b 
+initrd /image/initrd_a
+initrd /image/initrd_b
 boot
 `
 	assert.Equal(t, http.StatusOK, w.Code)


### PR DESCRIPTION
iPXE loads multiple initrds when each is given to it's own initrd command