### PR TITLE
*: Update Matchbox version to v0.7.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Notable changes between releases.
 
 ## Latest
 
+## v0.7.0 (2017-12-12)
+
 * Add gRPC API endpoints for managing generic (experimental) templates
 * Update Container Linux config transpiler to v0.5.0
 * Update Ignition to v0.19.0, render v2.1.0 Ignition configs

--- a/Documentation/deployment.md
+++ b/Documentation/deployment.md
@@ -20,23 +20,23 @@ Choose one of the supported installation options:
 Download the latest matchbox [release](https://github.com/coreos/matchbox/releases) to the provisioner host.
 
 ```sh
-$ wget https://github.com/coreos/matchbox/releases/download/v0.6.1/matchbox-v0.6.1-linux-amd64.tar.gz
-$ wget https://github.com/coreos/matchbox/releases/download/v0.6.1/matchbox-v0.6.1-linux-amd64.tar.gz.asc
+$ wget https://github.com/coreos/matchbox/releases/download/v0.7.0/matchbox-v0.7.0-linux-amd64.tar.gz
+$ wget https://github.com/coreos/matchbox/releases/download/v0.7.0/matchbox-v0.7.0-linux-amd64.tar.gz.asc
 ```
 
 Verify the release has been signed by the [CoreOS App Signing Key](https://coreos.com/security/app-signing-key/).
 
 ```sh
 $ gpg --keyserver pgp.mit.edu --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
-$ gpg --verify matchbox-v0.6.1-linux-amd64.tar.gz.asc matchbox-v0.6.1-linux-amd64.tar.gz
+$ gpg --verify matchbox-v0.7.0-linux-amd64.tar.gz.asc matchbox-v0.7.0-linux-amd64.tar.gz
 # gpg: Good signature from "CoreOS Application Signing Key <security@coreos.com>"
 ```
 
 Untar the release.
 
 ```sh
-$ tar xzvf matchbox-v0.6.1-linux-amd64.tar.gz
-$ cd matchbox-v0.6.1-linux-amd64
+$ tar xzvf matchbox-v0.7.0-linux-amd64.tar.gz
+$ cd matchbox-v0.7.0-linux-amd64
 ```
 
 ## Install

--- a/Documentation/dev/release.md
+++ b/Documentation/dev/release.md
@@ -8,7 +8,7 @@ This guide covers releasing new versions of matchbox.
 Create a release commit which updates old version references.
 
 ```sh
-$ export VERSION=v0.6.1
+$ export VERSION=v0.7.0
 ```
 
 ## Tag
@@ -45,7 +45,7 @@ $ make release
 Verify the reported version.
 
 ```
-./_output/matchbox-v0.6.1-linux-amd64/matchbox -version
+./_output/matchbox-v0.7.0-linux-amd64/matchbox -version
 ```
 
 ## Signing

--- a/Documentation/getting-started-rkt.md
+++ b/Documentation/getting-started-rkt.md
@@ -107,7 +107,7 @@ sudo rkt run --net=metal0:IP=172.18.0.2 \
   --volume data,kind=host,source=$PWD/examples \
   --mount volume=groups,target=/var/lib/matchbox/groups \
   --volume groups,kind=host,source=$PWD/examples/groups/etcd3 \
-  quay.io/coreos/matchbox:v0.6.1 -- -address=0.0.0.0:8080 -log-level=debug
+  quay.io/coreos/matchbox:v0.7.0 -- -address=0.0.0.0:8080 -log-level=debug
 ```
 ```sh
 sudo rkt run --net=metal0:IP=172.18.0.3 \

--- a/contrib/k8s/matchbox-deployment.yaml
+++ b/contrib/k8s/matchbox-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: matchbox
-          image: quay.io/coreos/matchbox:v0.6.1
+          image: quay.io/coreos/matchbox:v0.7.0
           env:
             - name: MATCHBOX_ADDRESS
               value: "0.0.0.0:8080"

--- a/contrib/systemd/matchbox-for-tectonic.service
+++ b/contrib/systemd/matchbox-for-tectonic.service
@@ -4,7 +4,7 @@ Documentation=https://github.com/coreos/matchbox
 
 [Service]
 Environment="IMAGE=quay.io/coreos/matchbox"
-Environment="VERSION=v0.6.1"
+Environment="VERSION=v0.7.0"
 Environment="MATCHBOX_ADDRESS=0.0.0.0:8080"
 Environment="MATCHBOX_RPC_ADDRESS=0.0.0.0:8081"
 Environment="MATCHBOX_LOG_LEVEL=debug"

--- a/contrib/systemd/matchbox-on-coreos.service
+++ b/contrib/systemd/matchbox-on-coreos.service
@@ -4,7 +4,7 @@ Documentation=https://github.com/coreos/matchbox
 
 [Service]
 Environment="IMAGE=quay.io/coreos/matchbox"
-Environment="VERSION=v0.6.1"
+Environment="VERSION=v0.7.0"
 Environment="MATCHBOX_ADDRESS=0.0.0.0:8080"
 ExecStartPre=/usr/bin/mkdir -p /etc/matchbox
 ExecStartPre=/usr/bin/mkdir -p /var/lib/matchbox/assets

--- a/scripts/devnet
+++ b/scripts/devnet
@@ -117,7 +117,7 @@ function rkt_create {
     --volume config,kind=host,source=$CONFIG_DIR,readOnly=true \
     --mount volume=data,target=/var/lib/matchbox \
     $DATA_MOUNT \
-    quay.io/coreos/matchbox:f26224c57dbea02adff0200037b14310ccdd2ebc -- -address=0.0.0.0:8080 -log-level=debug $MATCHBOX_ARGS
+    quay.io/coreos/matchbox:v0.7.0 -- -address=0.0.0.0:8080 -log-level=debug $MATCHBOX_ARGS
 
   echo "Starting dnsmasq to provide DHCP/TFTP/DNS services"
   rkt rm --uuid-file=/var/run/dnsmasq-pod.uuid > /dev/null 2>&1
@@ -174,7 +174,7 @@ function docker_create {
     -v $CONFIG_DIR:/etc/matchbox:Z \
     -v $ASSETS_DIR:/var/lib/matchbox/assets:Z \
     $DATA_MOUNT \
-    quay.io/coreos/matchbox:f26224c57dbea02adff0200037b14310ccdd2ebc -address=0.0.0.0:8080 -log-level=debug $MATCHBOX_ARGS
+    quay.io/coreos/matchbox:v0.7.0 -address=0.0.0.0:8080 -log-level=debug $MATCHBOX_ARGS
 
   echo "Starting dnsmasq to provide DHCP/TFTP/DNS services"
   docker run --name dnsmasq \


### PR DESCRIPTION
Holiday Release

* Add gRPC API endpoints for managing generic (experimental) templates
* Update Container Linux config transpiler to v0.5.0
* Update Ignition to v0.19.0, render v2.1.0 Ignition configs
* Drop support for Container Linux versions below 1465.0.0 (breaking)
* Build Matchbox with Go 1.8.5 for images and binaries
* Remove Profile `Cmdline` map (deprecated in v0.5.0), use `Args` slice instead
* Remove pixiecore support (deprecated in v0.5.0)
* Remove `ContextHandler`, `ContextHandlerFunc`, and `NewHandler` from the `matchbox/http` package.

### Examples / Modules

* Upgrade Kubernetes example clusters to v1.8.4
* Kubernetes examples clusters enable etcd TLS
* Deploy the Container Linux Update Operator (CLUO) to coordinate reboots of Container Linux nodes in Kubernetes clusters. See the cluster [addon docs](Documentation/cluster-addons.md).
* Kubernetes examples (terraform and non-terraform) mask locksmithd
* Terraform modules `bootkube` and `profiles` (Kubernetes) mask locksmithd
