### PR TITLE
scripts/tls: Fix cert-gen to add index.txt.attr

### DIFF
--- a/scripts/tls/cert-gen
+++ b/scripts/tls/cert-gen
@@ -15,6 +15,7 @@ echo "Creating example CA, server cert/key, and client cert/key..."
 # basic files/directories
 mkdir -p {certs,crl,newcerts}
 touch index.txt
+touch index.txt.attr
 echo 1000 > serial
 
 # CA private key (unencrypted)


### PR DESCRIPTION
Ensure an `index.txt.attr` file exists, it gets cleaned up at the beginning of the script.

Closes #690