### PR TITLE
Add kernel args variable

### DIFF
--- a/examples/terraform/bootkube-install/cluster.tf
+++ b/examples/terraform/bootkube-install/cluster.tf
@@ -33,4 +33,5 @@ module "cluster" {
   cached_install      = "${var.cached_install}"
   install_disk        = "${var.install_disk}"
   container_linux_oem = "${var.container_linux_oem}"
+  kernel_args         = "${var.kernel_args}"
 }

--- a/examples/terraform/bootkube-install/variables.tf
+++ b/examples/terraform/bootkube-install/variables.tf
@@ -108,3 +108,7 @@ variable "container_linux_oem" {
   default     = ""
   description = "Specify an OEM image id to use as base for the installation (e.g. ami, vmware_raw, xen) or leave blank for the default image"
 }
+
+variable "kernel_args" {
+  type        = "list"
+}


### PR DESCRIPTION
Add the `kernel_args` variable in order to pass additional arguments to the kernel. For example, one can pass `coreos.autologin` to the kernel for debugging.