### PR TITLE
travis: update to latest supported go major versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,15 @@ sudo: required
 services:
   - docker
 go:
-  - 1.7.x
-  - 1.8.x
-  - 1.8.5
-  - 1.9.x
+  - 1.10.x
+  - 1.11.x
+  - 1.11.1
   - tip
 matrix:
   allow_failures:
     - go: tip
 install:
-  - go get github.com/golang/lint/golint
+  - go get golang.org/x/lint/golint
 script:
   - make test
 deploy:
@@ -21,6 +20,6 @@ deploy:
   skip_cleanup: true
   on:
     branch: master
-    go: '1.8.5'
+    go: '1.11.1'
 notifications:
   email: change


### PR DESCRIPTION
this also fixes the golint url to use the new location, to fix ci.