### PR TITLE
Update Kubernetes (terraform) example to v1.12.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ Notable changes between releases.
 
 ## Latest
 
+### Examples
+
+* Upgrade Kubernetes example clusters to v1.12.3 (Terraform-based)
+
 ## v0.7.1 (2018-11-01)
 
 * Add `kernel_args` variable to the terraform bootkube-install cluster definition

--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -39,8 +39,8 @@ GET http://matchbox.foo/ipxe?label=value
 
 ```
 #!ipxe
-kernel /assets/coreos/1576.5.0/coreos_production_pxe.vmlinuz coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp} coreos.first_boot=1 coreos.autologin
-initrd  /assets/coreos/1576.5.0/coreos_production_pxe_image.cpio.gz
+kernel /assets/coreos/1911.4.0/coreos_production_pxe.vmlinuz coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp} coreos.first_boot=1 coreos.autologin
+initrd  /assets/coreos/1911.4.0/coreos_production_pxe_image.cpio.gz
 boot
 ```
 
@@ -67,9 +67,9 @@ default=0
 timeout=1
 menuentry "CoreOS" {
 echo "Loading kernel"
-linuxefi "(http;matchbox.foo:8080)/assets/coreos/1576.5.0/coreos_production_pxe.vmlinuz" "coreos.autologin" "coreos.config.url=http://matchbox.foo:8080/ignition" "coreos.first_boot"
+linuxefi "(http;matchbox.foo:8080)/assets/coreos/1911.4.0/coreos_production_pxe.vmlinuz" "coreos.autologin" "coreos.config.url=http://matchbox.foo:8080/ignition" "coreos.first_boot"
 echo "Loading initrd"
-initrdefi "(http;matchbox.foo:8080)/assets/coreos/1576.5.0/coreos_production_pxe_image.cpio.gz"
+initrdefi "(http;matchbox.foo:8080)/assets/coreos/1911.4.0/coreos_production_pxe_image.cpio.gz"
 }
 ```
 
@@ -231,7 +231,7 @@ If you need to serve static assets (e.g. kernel, initrd), `matchbox` can serve a
 ```
 matchbox.foo/assets/
 └── coreos
-    └── 1576.5.0
+    └── 1911.4.0
         ├── coreos_production_pxe.vmlinuz
         └── coreos_production_pxe_image.cpio.gz
     └── 1153.0.0

--- a/Documentation/bootkube.md
+++ b/Documentation/bootkube.md
@@ -30,7 +30,7 @@ The [examples](../examples) statically assign IP addresses to libvirt client VMs
 Download the CoreOS Container Linux image assets referenced in the target [profile](../examples/profiles).
 
 ```sh
-$ ./scripts/get-coreos stable 1576.5.0 ./examples/assets
+$ ./scripts/get-coreos stable 1911.4.0 ./examples/assets
 ```
 
 Add your SSH public key to each machine group definition [as shown](../examples/README.md#ssh-keys).

--- a/Documentation/deployment.md
+++ b/Documentation/deployment.md
@@ -218,7 +218,7 @@ Certificate chain
 Download a recent Container Linux [release](https://coreos.com/releases/) with signatures.
 
 ```sh
-$ ./scripts/get-coreos stable 1576.5.0 .     # note the "." 3rd argument
+$ ./scripts/get-coreos stable 1911.4.0 .     # note the "." 3rd argument
 ```
 
 Move the images to `/var/lib/matchbox/assets`,
@@ -230,7 +230,7 @@ $ sudo cp -r coreos /var/lib/matchbox/assets
 ```
 /var/lib/matchbox/assets/
 ├── coreos
-│   └── 1576.5.0
+│   └── 1911.4.0
 │       ├── CoreOS_Image_Signing_Key.asc
 │       ├── coreos_production_image.bin.bz2
 │       ├── coreos_production_image.bin.bz2.sig
@@ -243,7 +243,7 @@ $ sudo cp -r coreos /var/lib/matchbox/assets
 and verify the images are acessible.
 
 ```sh
-$ curl http://matchbox.example.com:8080/assets/coreos/1576.5.0/
+$ curl http://matchbox.example.com:8080/assets/coreos/1911.4.0/
 <pre>...
 ```
 

--- a/Documentation/getting-started-docker.md
+++ b/Documentation/getting-started-docker.md
@@ -28,7 +28,7 @@ $ cd matchbox
 Download CoreOS Container Linux image assets referenced by the `etcd3` [example](../examples) to `examples/assets`.
 
 ```sh
-$ ./scripts/get-coreos stable 1576.5.0 ./examples/assets
+$ ./scripts/get-coreos stable 1911.4.0 ./examples/assets
 ```
 
 For development convenience, add `/etc/hosts` entries for nodes so they may be referenced by name.

--- a/Documentation/getting-started-rkt.md
+++ b/Documentation/getting-started-rkt.md
@@ -30,7 +30,7 @@ $ cd matchbox
 Download CoreOS Container Linux image assets referenced by the `etcd3` [example](../examples) to `examples/assets`.
 
 ```sh
-$ ./scripts/get-coreos stable 1576.5.0 ./examples/assets
+$ ./scripts/get-coreos stable 1911.4.0 ./examples/assets
 ```
 
 ## Network

--- a/Documentation/matchbox.md
+++ b/Documentation/matchbox.md
@@ -64,8 +64,8 @@ Profiles reference an Ignition config, Cloud-Config, and/or generic config by na
   "ignition_id": "etcd.yaml",
   "generic_id": "some-service.cfg",
   "boot": {
-    "kernel": "/assets/coreos/1576.5.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1576.5.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1911.4.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1911.4.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "coreos.config.url=http://matchbox.foo:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",
       "coreos.first_boot=yes",

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
   * [Kubernetes](Documentation/bootkube.md) - Install a 3-node Kubernetes v1.8.5 cluster
 * Clusters (Terraform-based)
   * [etcd3](examples/terraform/etcd3-install/README.md) - Install a 3-node etcd3 cluster
-  * [Kubernetes](examples/terraform/bootkube-install/README.md) - Install a 3-node Kubernetes v1.10.3 cluster
+  * [Kubernetes](examples/terraform/bootkube-install/README.md) - Install a 3-node Kubernetes v1.12.3 cluster
 
 ### Projects
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ These examples use [Terraform](https://www.terraform.io/intro/) as a client to M
 |-------------------------------|-------------------------------|
 | [simple-install](terraform/simple-install/) | Install Container Linux with an SSH key |
 | [etcd3-install](terraform/etcd3-install/) | Install a 3-node etcd3 cluster |
-| [bootkube-install](terraform/bootkube-install/) | Install a 3-node Kubernetes v1.10.3 cluster |
+| [bootkube-install](terraform/bootkube-install/) | Install a 3-node Kubernetes v1.12.3 cluster |
 
 ### Customization
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,13 +22,13 @@ These examples mount raw Matchbox objects into a Matchbox server's `/var/lib/mat
 
 | Name       | Description | CoreOS Container Linux Version | FS | Docs |
 |------------|-------------|----------------|----|-----------|
-| simple | CoreOS Container Linux with autologin, using iPXE | stable/1576.5.0 | RAM | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
-| simple-install | CoreOS Container Linux Install, using iPXE | stable/1576.5.0 | RAM | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
-| grub | CoreOS Container Linux via GRUB2 Netboot | stable/1576.5.0 | RAM | NA |
-| etcd3 | PXE boot a 3-node etcd3 cluster with proxies | stable/1576.5.0 | RAM | None |
-| etcd3-install | Install a 3-node etcd3 cluster to disk | stable/1576.5.0 | Disk | None |
-| bootkube | PXE boot a 3-node Kubernetes v1.8.5 cluster | stable/1576.5.0 | Disk | [tutorial](../Documentation/bootkube.md) |
-| bootkube-install | Install a 3-node Kubernetes v1.8.5 cluster | stable/1576.5.0 | Disk | [tutorial](../Documentation/bootkube.md) |
+| simple | CoreOS Container Linux with autologin, using iPXE | stable/1911.4.0 | RAM | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
+| simple-install | CoreOS Container Linux Install, using iPXE | stable/1911.4.0 | RAM | [reference](https://coreos.com/os/docs/latest/booting-with-ipxe.html) |
+| grub | CoreOS Container Linux via GRUB2 Netboot | stable/1911.4.0 | RAM | NA |
+| etcd3 | PXE boot a 3-node etcd3 cluster with proxies | stable/1911.4.0 | RAM | None |
+| etcd3-install | Install a 3-node etcd3 cluster to disk | stable/1911.4.0 | Disk | None |
+| bootkube | PXE boot a 3-node Kubernetes v1.8.5 cluster | stable/1911.4.0 | Disk | [tutorial](../Documentation/bootkube.md) |
+| bootkube-install | Install a 3-node Kubernetes v1.8.5 cluster | stable/1911.4.0 | Disk | [tutorial](../Documentation/bootkube.md) |
 
 ### Customization
 

--- a/examples/groups/bootkube-install/install.json
+++ b/examples/groups/bootkube-install/install.json
@@ -4,7 +4,7 @@
   "profile": "install-reboot",
   "metadata": {
     "coreos_channel": "stable",
-    "coreos_version": "1576.5.0",
+    "coreos_version": "1911.4.0",
     "ignition_endpoint": "http://matchbox.example.com:8080/ignition",
     "baseurl": "http://matchbox.example.com:8080/assets/coreos"
   }

--- a/examples/groups/etcd3-install/install.json
+++ b/examples/groups/etcd3-install/install.json
@@ -4,7 +4,7 @@
   "profile": "install-reboot",
   "metadata": {
     "coreos_channel": "stable",
-    "coreos_version": "1576.5.0",
+    "coreos_version": "1911.4.0",
     "ignition_endpoint": "http://matchbox.example.com:8080/ignition",
     "baseurl": "http://matchbox.example.com:8080/assets/coreos"
   }

--- a/examples/groups/simple-install/install.json
+++ b/examples/groups/simple-install/install.json
@@ -4,7 +4,7 @@
   "profile": "simple-install",
   "metadata": {
     "coreos_channel": "stable",
-    "coreos_version": "1576.5.0",
+    "coreos_version": "1911.4.0",
     "ignition_endpoint": "http://matchbox.example.com:8080/ignition",
     "baseurl": "http://matchbox.example.com:8080/assets/coreos"
   }

--- a/examples/profiles/bootkube-controller.json
+++ b/examples/profiles/bootkube-controller.json
@@ -2,8 +2,8 @@
   "id": "bootkube-controller",
   "name": "bootkube Ready Controller",
   "boot": {
-    "kernel": "/assets/coreos/1576.5.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1576.5.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1911.4.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1911.4.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "initrd=coreos_production_pxe_image.cpio.gz",
       "root=/dev/sda1",

--- a/examples/profiles/bootkube-worker.json
+++ b/examples/profiles/bootkube-worker.json
@@ -2,8 +2,8 @@
   "id": "bootkube-worker",
   "name": "bootkube Ready Worker",
   "boot": {
-    "kernel": "/assets/coreos/1576.5.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1576.5.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1911.4.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1911.4.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "initrd=coreos_production_pxe_image.cpio.gz",
       "root=/dev/sda1",

--- a/examples/profiles/etcd3-gateway.json
+++ b/examples/profiles/etcd3-gateway.json
@@ -2,8 +2,8 @@
   "id": "etcd3-gateway",
   "name": "etcd3-gateway",
   "boot": {
-    "kernel": "/assets/coreos/1576.5.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1576.5.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1911.4.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1911.4.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "initrd=coreos_production_pxe_image.cpio.gz",
       "coreos.config.url=http://matchbox.example.com:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",

--- a/examples/profiles/etcd3.json
+++ b/examples/profiles/etcd3.json
@@ -2,8 +2,8 @@
   "id": "etcd3",
   "name": "etcd3",
   "boot": {
-    "kernel": "/assets/coreos/1576.5.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1576.5.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1911.4.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1911.4.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "initrd=coreos_production_pxe_image.cpio.gz",
       "coreos.config.url=http://matchbox.example.com:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",

--- a/examples/profiles/grub.json
+++ b/examples/profiles/grub.json
@@ -2,8 +2,8 @@
   "id": "grub",
   "name": "CoreOS Container Linux via GRUB2",
   "boot": {
-    "kernel": "(http;matchbox.example.com:8080)/assets/coreos/1576.5.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["(http;matchbox.example.com:8080)/assets/coreos/1576.5.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "(http;matchbox.example.com:8080)/assets/coreos/1911.4.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["(http;matchbox.example.com:8080)/assets/coreos/1911.4.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "coreos.config.url=http://matchbox.example.com:8080/ignition",
       "coreos.first_boot=yes",

--- a/examples/profiles/install-reboot.json
+++ b/examples/profiles/install-reboot.json
@@ -2,8 +2,8 @@
   "id": "install-reboot",
   "name": "Install CoreOS Container Linux and Reboot",
   "boot": {
-    "kernel": "/assets/coreos/1576.5.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1576.5.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1911.4.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1911.4.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "initrd=coreos_production_pxe_image.cpio.gz",
       "coreos.config.url=http://matchbox.example.com:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",

--- a/examples/profiles/simple-install.json
+++ b/examples/profiles/simple-install.json
@@ -2,8 +2,8 @@
   "id": "simple-install",
   "name": "Simple CoreOS Container Linux Alpha Install",
   "boot": {
-    "kernel": "/assets/coreos/1576.5.0/coreos_production_pxe.vmlinuz",
-    "initrd": ["/assets/coreos/1576.5.0/coreos_production_pxe_image.cpio.gz"],
+    "kernel": "/assets/coreos/1911.4.0/coreos_production_pxe.vmlinuz",
+    "initrd": ["/assets/coreos/1911.4.0/coreos_production_pxe_image.cpio.gz"],
     "args": [
       "initrd=coreos_production_pxe_image.cpio.gz",
       "coreos.config.url=http://matchbox.example.com:8080/ignition?uuid=${uuid}&mac=${mac:hexhyp}",

--- a/examples/profiles/simple.json
+++ b/examples/profiles/simple.json
@@ -2,9 +2,9 @@
   "id": "simple",
   "name": "Simple CoreOS Container Linux Alpha",
   "boot": {
-    "kernel": "/assets/coreos/1576.5.0/coreos_production_pxe.vmlinuz",
+    "kernel": "/assets/coreos/1911.4.0/coreos_production_pxe.vmlinuz",
     "initrd": [
-      "/assets/coreos/1576.5.0/coreos_production_pxe_image.cpio.gz"
+      "/assets/coreos/1911.4.0/coreos_production_pxe_image.cpio.gz"
     ],
     "args": [
       "initrd=coreos_production_pxe_image.cpio.gz",

--- a/examples/terraform/bootkube-install/README.md
+++ b/examples/terraform/bootkube-install/README.md
@@ -1,6 +1,6 @@
 # Kubernetes
 
-The Kubernetes example shows how to use Matchbox to network boot and provision a 3 node Kubernetes v1.10.3 cluster. This example uses [Terraform](https://www.terraform.io/intro/index.html) and a module provided by [Typhoon](https://github.com/poseidon/typhoon) to describe cluster resources. [kubernetes-incubator/bootkube](https://github.com/kubernetes-incubator/bootkube) is run once to bootstrap the Kubernetes control plane.
+The Kubernetes example shows how to use Matchbox to network boot and provision a 3 node Kubernetes v1.12.3 cluster. This example uses [Terraform](https://www.terraform.io/intro/index.html) and a module provided by [Typhoon](https://github.com/poseidon/typhoon) to describe cluster resources. [kubernetes-incubator/bootkube](https://github.com/kubernetes-incubator/bootkube) is run once to bootstrap the Kubernetes control plane.
 
 ## Requirements
 
@@ -81,15 +81,6 @@ Initialize Terraform from the `bootkube-install` directory.
 terraform init
 ```
 
-Get or update Terraform modules.
-
-```sh
-$ terraform get            # downloads missing modules
-$ terraform get --update   # updates all modules
-Get: git::https://github.com/poseidon/typhoon (update)
-Get: git::https://github.com/poseidon/bootkube-terraform.git?ref=v0.11.0 (update)
-```
-
 Plan the resources to be created.
 
 ```sh
@@ -149,19 +140,20 @@ $ sudo ./scripts/libvirt [start|reboot|shutdown|poweroff|destroy]
 $ export KUBECONFIG=assets/auth/kubeconfig
 $ kubectl get nodes
 NAME                STATUS    AGE       VERSION
-node1.example.com   Ready     11m       v1.10.0
-node2.example.com   Ready     11m       v1.10.0
-node3.example.com   Ready     11m       v1.10.0
+node1.example.com   Ready     11m       v1.12.3
+node2.example.com   Ready     11m       v1.12.3
+node3.example.com   Ready     11m       v1.12.3
 
 $ kubectl get pods --all-namespaces
 NAMESPACE     NAME                                       READY     STATUS    RESTARTS   AGE
-kube-system   kube-flannel-fqp7f                         2/2       Running   1          11m
-kube-system   kube-flannel-gnjrm                         2/2       Running   0          11m
-kube-system   kube-flannel-llbgt                         2/2       Running   0          11m
+kube-system   coredns-1187388186-mx9rt                   3/3       Running   0          11m
+kube-system   coredns-1187388186-dsfk3                   3/3       Running   0          11m
+kube-system   flannel-fqp7f                              2/2       Running   1          11m
+kube-system   flannel-gnjrm                              2/2       Running   0          11m
+kube-system   flannel-llbgt                              2/2       Running   0          11m
 kube-system   kube-apiserver-7336w                       1/1       Running   0          11m
 kube-system   kube-controller-manager-3271970485-b9chx   1/1       Running   0          11m
 kube-system   kube-controller-manager-3271970485-v30js   1/1       Running   1          11m
-kube-system   kube-dns-1187388186-mx9rt                  3/3       Running   0          11m
 kube-system   kube-proxy-50sd4                           1/1       Running   0          11m
 kube-system   kube-proxy-bczhp                           1/1       Running   0          11m
 kube-system   kube-proxy-mp2fw                           1/1       Running   0          11m

--- a/examples/terraform/bootkube-install/README.md
+++ b/examples/terraform/bootkube-install/README.md
@@ -36,7 +36,7 @@ ssh_authorized_key = "ADD ME"
 
 cluster_name = "demo"
 os_channel   = "coreos-stable"
-os_version   = "1576.5.0"
+os_version   = "1911.4.0"
 ```
 
 Provide an ordered list of controller names, MAC addresses, and domain names. Provide an ordered list of worker names, MAC addresses, and domain names.

--- a/examples/terraform/bootkube-install/cluster.tf
+++ b/examples/terraform/bootkube-install/cluster.tf
@@ -1,6 +1,6 @@
 // Kubernetes cluster
 module "cluster" {
-  source = "git::https://github.com/poseidon/typhoon//bare-metal/container-linux/kubernetes?ref=v1.10.3"
+  source = "git::https://github.com/poseidon/typhoon//bare-metal/container-linux/kubernetes?ref=v1.12.3"
 
   providers = {
     local = "local.default"

--- a/examples/terraform/bootkube-install/multi-controller.tfvars.example
+++ b/examples/terraform/bootkube-install/multi-controller.tfvars.example
@@ -4,7 +4,7 @@ matchbox_rpc_endpoint = "matchbox.example.com:8081"
 
 cluster_name = "example"
 os_channel   = "coreos-stable"
-os_version   = "1576.5.0"
+os_version   = "1911.4.0"
 
 # Machines
 controller_names = ["node1", "node2", "node3"]

--- a/examples/terraform/bootkube-install/terraform.tfvars.example
+++ b/examples/terraform/bootkube-install/terraform.tfvars.example
@@ -4,7 +4,7 @@ matchbox_rpc_endpoint = "matchbox.example.com:8081"
 
 cluster_name = "example"
 os_channel = "coreos-stable"
-os_version = "1576.5.0"
+os_version = "1911.4.0"
 
 # Machines
 controller_names = ["node1"]

--- a/examples/terraform/etcd3-install/etcd3.tf
+++ b/examples/terraform/etcd3-install/etcd3.tf
@@ -2,7 +2,7 @@
 module "profiles" {
   source                  = "../modules/profiles"
   matchbox_http_endpoint  = "${var.matchbox_http_endpoint}"
-  container_linux_version = "1576.5.0"
+  container_linux_version = "1911.4.0"
   container_linux_channel = "stable"
   install_disk            = "${var.install_disk}"
   container_linux_oem     = "${var.container_linux_oem}"

--- a/scripts/devnet
+++ b/scripts/devnet
@@ -15,7 +15,7 @@ ASSETS_DIR="${ASSETS_DIR:-$PWD/examples/assets}"
 CONFIG_DIR="${CONFIG_DIR:-$PWD/examples/etc/matchbox}"
 
 COREOS_CHANNEL=stable
-COREOS_VERSION=1576.5.0
+COREOS_VERSION=1911.4.0
 MATCHBOX_ARGS=""
 
 if [ "$EUID" -ne 0 ]

--- a/scripts/get-coreos
+++ b/scripts/get-coreos
@@ -9,7 +9,7 @@ set -eou pipefail
 GPG=${GPG:-/usr/bin/gpg}
 
 CHANNEL=${1:-"stable"}
-VERSION=${2:-"1576.5.0"}
+VERSION=${2:-"1911.4.0"}
 DEST_DIR=${3:-"$PWD/examples/assets"}
 OEM_ID=${OEM_ID:-""}
 DEST=$DEST_DIR/coreos/$VERSION

--- a/tests/smoke/bootkube.tfvars
+++ b/tests/smoke/bootkube.tfvars
@@ -3,7 +3,7 @@ matchbox_rpc_endpoint = "matchbox.example.com:8081"
 ssh_authorized_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDPQFdwVLr+alsWIgYRz9OdqDhnx9jjuFbkdSdpqq4gd9uZApYlivMDD4UgjFazQpezx8DiNhu9ym7i6LgAcdwi+10hE4L9yoJv9uBgbBxOAd65znqLqF91NtV4mlKP5YfJtR7Ehs+pTB+IIC+o5veDbPn+BYgDMJ2x7Osbn1/gFSDken/yoOFbYbRMGMfVEQYjJzC4r/qCKH0bl/xuVNLxf9FkWSTCcQFKGOndwuGITDkshD4r2Kk8gUddXPxoahBv33/2QH0CY5zbKYjhgN6I6WtwO+O1uJwtNeV1AGhYjurdd60qggNwx+W7623uK3nIXvJd3hzDO8u5oa53/tIL fake-test-key"
 
 cluster_name = "example"
-container_linux_version = "1576.5.0"
+container_linux_version = "1911.4.0"
 container_linux_channel = "stable"
 
 # Machines


### PR DESCRIPTION
Update Container Linux from 1576.5.0 to 1911.4.0 since newer ignition configs may be in use (depending on terraform-provider-ct version)