### PR TITLE
Update Go version from v1.11.1 to v1.11.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 go:
   - 1.10.x
   - 1.11.x
-  - 1.11.1
+  - 1.11.5
   - tip
 matrix:
   allow_failures:
@@ -20,6 +20,6 @@ deploy:
   skip_cleanup: true
   on:
     branch: master
-    go: '1.11.1'
+    go: '1.11.5'
 notifications:
   email: change


### PR DESCRIPTION
* Test changes on Travis using the current Go v1.11.x release
* Push container images built with Go v1.11.5