### PR TITLE
Update coreos/dnsmasq image and automate deploys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,18 @@ install:
 script:
   - make
 deploy:
-  provider: script
-  script: scripts/dev/travis-docker-push
-  skip_cleanup: true
-  on:
-    branch: master
-    go: '1.11.5'
+  - provider: script
+    script: scripts/dev/travis-docker-push
+    skip_cleanup: true
+    on:
+      branch: master
+      go: '1.11.5'
+  - provider: script
+    script: contrib/dnsmasq/travis-deploy
+    skip_cleanup: true
+    on:
+      branch: dnsmasq
+      # pick one, so travis deploys once
+      go: '1.10.x'
 notifications:
   email: change

--- a/contrib/dnsmasq/Dockerfile
+++ b/contrib/dnsmasq/Dockerfile
@@ -1,5 +1,5 @@
-FROM alpine:3.6
-MAINTAINER Dalton Hubble <dalton.hubble@coreos.com>
+FROM alpine:3.9
+LABEL maintainer="Dalton Hubble <dghubble@gmail.com>"
 RUN apk -U add dnsmasq curl
 COPY tftpboot /var/lib/tftpboot
 EXPOSE 53 67 69

--- a/contrib/dnsmasq/Makefile
+++ b/contrib/dnsmasq/Makefile
@@ -1,4 +1,5 @@
-VERSION=v0.5.0
+DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+VERSION=$(shell git describe --tags --match=v* --always --dirty)
 
 IMAGE_REPO=coreos/dnsmasq
 QUAY_REPO=quay.io/coreos/dnsmasq
@@ -8,7 +9,7 @@ all: docker-image
 
 .PHONY: tftp
 tftp:
-	@./get-tftp-files
+	@$(DIR)/get-tftp-files
 
 .PHONY: docker-image
 docker-image: tftp

--- a/contrib/dnsmasq/travis-deploy
+++ b/contrib/dnsmasq/travis-deploy
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+# dirty hack
+cd "$(dirname $0)"
+
+docker info
+make docker-image
+docker login -u="$DOCKER_USERNAME" -p=$DOCKER_PASSWORD quay.io
+make docker-push
+


### PR DESCRIPTION
* Automatically publish dnsmasq image on merge to a branch named "dnsmasq". Similar to how matchbox is automatically published from master. Set the version based on git SHA
* Update base image from alpine:3.6 to alpine:3.9 to address #712
* https://docs.travis-ci.com/user/deployment#deploying-to-multiple-providers

Followups:
Need push access and if everything is working, `dnsmasq` branch should probably be protected.